### PR TITLE
Fix composer draft cleared when switching tabs (v0.63.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin-fabricator",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "description": "Fabricator — a desktop app for building Rayfin apps via chat, wrapping the GitHub Copilot CLI and the Rayfin CLI.",
   "author": "Sachin Patney (https://github.com/spatney)",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3108,7 +3108,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayfin-fabricator"
-version = "0.63.0"
+version = "0.63.1"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayfin-fabricator"
-version = "0.63.0"
+version = "0.63.1"
 description = "Fabricator — a desktop app for building Rayfin apps via chat, wrapping the GitHub Copilot CLI and the Rayfin CLI."
 authors = ["Fabricator"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rayfin Fabricator",
-  "version": "0.63.0",
+  "version": "0.63.1",
   "identifier": "com.rayfin.fabricator",
   "build": {
     "frontendDist": "../dist",

--- a/src/renderer/src/components/ChatPanel.test.tsx
+++ b/src/renderer/src/components/ChatPanel.test.tsx
@@ -1,0 +1,128 @@
+import { useMemo, useState } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { makeProject } from '../../test/harness'
+import ChatPanel from './ChatPanel'
+
+/**
+ * Guards issue #9: a typed-but-unsent prompt must survive ChatPanel unmounting.
+ * The Build view renders ChatPanel only while `viewMode === 'build'`, so switching
+ * to the Code tab tears the panel down; the composer draft is therefore lifted to
+ * the parent (keyed by project) and re-seeded on remount. These tests exercise that
+ * contract through a small parent harness that mirrors Workbench's draft plumbing.
+ */
+
+const PLACEHOLDER = /Message Fabricator about/i
+
+/** Minimal `window.api` surface ChatPanel touches on mount / while typing. */
+function installApi(): void {
+  ;(window as unknown as { api: unknown }).api = {
+    onChatEvent: vi.fn(() => () => {}),
+    chat: {
+      suggest: vi.fn(() => Promise.resolve({ ok: false, suggestions: [] })),
+      cancelSuggest: vi.fn(() => Promise.resolve(true)),
+      setOptions: vi.fn(() => Promise.resolve(undefined)),
+      listModels: vi.fn(() => Promise.resolve([]))
+    },
+    projects: { files: { tree: vi.fn(() => Promise.resolve({ path: '', name: '', children: [] })) } },
+    screenshot: { save: vi.fn(() => Promise.resolve('C:/tmp/shot.png')) }
+  }
+}
+
+/**
+ * Mirrors how Workbench keeps a per-project composer draft and conditionally
+ * mounts ChatPanel. `onCode` flips the panel off (Code tab) and back (Build tab).
+ */
+function Harness({ initialDraft = '' }: { initialDraft?: string }): JSX.Element {
+  const [drafts, setDrafts] = useState<Record<string, string>>(
+    initialDraft ? { p1: initialDraft } : {}
+  )
+  const [onCode, setOnCode] = useState(false)
+  const project = useMemo(() => makeProject('p1'), [])
+  return (
+    <div>
+      <button type="button" onClick={() => setOnCode((v) => !v)}>
+        toggle-tab
+      </button>
+      {!onCode && (
+        <ChatPanel
+          project={project}
+          messages={[]}
+          onChange={() => {}}
+          draft={drafts.p1 ?? ''}
+          onDraftChange={(value) => setDrafts((all) => ({ ...all, p1: value }))}
+        />
+      )}
+    </div>
+  )
+}
+
+async function toggleTab(): Promise<void> {
+  await act(async () => {
+    fireEvent.click(screen.getByText('toggle-tab'))
+  })
+}
+
+let raf: typeof globalThis.requestAnimationFrame | undefined
+let cancelRaf: typeof globalThis.cancelAnimationFrame | undefined
+
+beforeEach(() => {
+  installApi()
+  // jsdom may not expose rAF; ChatPanel's scroll/flush effects rely on it.
+  if (!globalThis.requestAnimationFrame) {
+    raf = globalThis.requestAnimationFrame
+    cancelRaf = globalThis.cancelAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) =>
+      setTimeout(() => cb(Date.now()), 0) as unknown as number) as typeof requestAnimationFrame
+    globalThis.cancelAnimationFrame = ((id: number) =>
+      clearTimeout(id)) as typeof cancelAnimationFrame
+  }
+})
+
+afterEach(() => {
+  cleanup()
+  if (raf) {
+    globalThis.requestAnimationFrame = raf
+    globalThis.cancelAnimationFrame = cancelRaf as typeof cancelAnimationFrame
+    raf = undefined
+    cancelRaf = undefined
+  }
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('ChatPanel composer draft', () => {
+  it('preserves a typed-but-unsent prompt when navigating to Code and back (issue #9)', async () => {
+    render(<Harness />)
+
+    const ta = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement
+    await act(async () => {
+      fireEvent.change(ta, { target: { value: 'build me a sales dashboard' } })
+    })
+    expect(ta.value).toBe('build me a sales dashboard')
+
+    // Switch to the Code tab — ChatPanel unmounts.
+    await toggleTab()
+    expect(screen.queryByPlaceholderText(PLACEHOLDER)).toBeNull()
+
+    // Return to Build — ChatPanel remounts and must restore the draft.
+    await toggleTab()
+    const restored = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement
+    expect(restored.value).toBe('build me a sales dashboard')
+  })
+
+  it('seeds the composer from the persisted draft on first mount', async () => {
+    await act(async () => {
+      render(<Harness initialDraft="a prompt I left earlier" />)
+    })
+    const ta = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement
+    expect(ta.value).toBe('a prompt I left earlier')
+  })
+
+  it('starts empty when there is no persisted draft', async () => {
+    await act(async () => {
+      render(<Harness />)
+    })
+    const ta = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement
+    expect(ta.value).toBe('')
+  })
+})

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -121,6 +121,12 @@ interface Props {
   modeSelectorEnabled?: boolean
   /** Open a file referenced by an @-mention chip (path without the leading @). */
   onOpenMention?: (ref: string) => void
+  /** The current composer draft. Persisted by the parent (keyed by project) so a
+   * typed-but-unsent prompt survives this panel unmounting — e.g. switching to the
+   * Code tab and back to Build tears down ChatPanel (issue #9). */
+  draft?: string
+  /** Called whenever the composer draft changes so the parent can persist it. */
+  onDraftChange?: (value: string) => void
 }
 
 /** Reasoning efforts shown when the engine's per-model list is unavailable
@@ -1436,9 +1442,25 @@ export default function ChatPanel({
   deploying = false,
   onRequestDeploy,
   modeSelectorEnabled = false,
-  onOpenMention
+  onOpenMention,
+  draft,
+  onDraftChange
 }: Props): JSX.Element {
-  const [input, setInput] = useState('')
+  // The composer draft is seeded from — and mirrored back to — the parent so a
+  // typed-but-unsent prompt survives this panel unmounting. Switching to the Code
+  // tab and back to Build tears down ChatPanel, and local state alone would be
+  // lost (issue #9). The parent keys the draft by project, so each project keeps
+  // its own pending prompt.
+  const onDraftChangeRef = useRef(onDraftChange)
+  onDraftChangeRef.current = onDraftChange
+  const [input, setInputState] = useState(draft ?? '')
+  const setInput = useCallback((next: string | ((prev: string) => string)): void => {
+    setInputState((prev) => {
+      const value = typeof next === 'function' ? next(prev) : next
+      onDraftChangeRef.current?.(value)
+      return value
+    })
+  }, [])
   const [sending, setSending] = useState(false)
   // Recover the in-flight state when the panel remounts mid-turn — switching
   // workbench tabs/projects or a dev hot-reload tears down this component while

--- a/src/renderer/src/screens/Workbench.tsx
+++ b/src/renderer/src/screens/Workbench.tsx
@@ -183,6 +183,9 @@ export default function Workbench({
   const [deploys, setDeploys] = useState<Record<string, DeployUiState>>({})
   /** Region screenshots staged per project for the next chat message. */
   const [shots, setShots] = useState<Record<string, PendingShot[]>>({})
+  /** Composer drafts staged per project — a typed-but-unsent prompt persists here
+   * so it survives ChatPanel unmounting when switching tabs (Build ⇄ Code). */
+  const [drafts, setDrafts] = useState<Record<string, string>>({})
   /** The project whose `rayfin up` is currently streaming (routes deploy:run logs). */
   const deployingIdRef = useRef<string | null>(null)
   /** Latest chats snapshot, for reading inside async callbacks / save timers. */
@@ -219,6 +222,10 @@ export default function Workbench({
 
   const clearShots = useCallback((key: string): void => {
     setShots((all) => ({ ...all, [key]: [] }))
+  }, [])
+
+  const setDraftFor = useCallback((key: string, value: string): void => {
+    setDrafts((all) => ({ ...all, [key]: value }))
   }, [])
 
   const setMessagesFor = useCallback(
@@ -897,6 +904,8 @@ export default function Workbench({
                       onRequestDeploy={() => setCreateMode('deploy')}
                       modeSelectorEnabled={Boolean(settings?.experiments?.chatModeSelector)}
                       onOpenMention={openMention}
+                      draft={drafts[active.id] ?? ''}
+                      onDraftChange={(value) => setDraftFor(active.id, value)}
                     />
                   </section>
                   {!focusPane && (


### PR DESCRIPTION
## Summary
Fixes #9 — a typed-but-unsent chat prompt was cleared when navigating from the **Build** tab to **Code** and back.

## Root cause
The Build view renders `<ChatPanel>` only while `viewMode === 'build'` (`Workbench.tsx`). Switching to the Code tab therefore **unmounts** ChatPanel, and its composer text lived in a local `useState('')`. On return to Build the panel remounts fresh, so the draft was lost. (Chat history survived because it's owned by the parent; the composer draft was not.)

## Fix
Lift the composer draft to `Workbench`, keyed by project id — mirroring the existing per-project staged-screenshots (`shots`) pattern:
- `Workbench` holds `drafts: Record<string, string>` and passes `draft` + `onDraftChange` to `ChatPanel`.
- `ChatPanel` seeds its `input` from `draft` on mount and mirrors every change back to the parent, so the prompt survives the unmount/remount. Each project keeps its own draft.

## Tests
Adds `ChatPanel.test.tsx` (3 tests) reproducing the exact issue: type into the composer, unmount (Code tab), remount (Build) → the draft is restored. Verified the tests **fail** without the fix.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (13 tests)

Release: **v0.63.1**.
