### PR TITLE
Disable auto-capitalize/correct on the Project name field (v0.63.2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rayfin-fabricator",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "description": "Fabricator — a desktop app for building Rayfin apps via chat, wrapping the GitHub Copilot CLI and the Rayfin CLI.",
   "author": "Sachin Patney (https://github.com/spatney)",
   "license": "MIT",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3108,7 +3108,7 @@ checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
 name = "rayfin-fabricator"
-version = "0.63.1"
+version = "0.63.2"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rayfin-fabricator"
-version = "0.63.1"
+version = "0.63.2"
 description = "Fabricator — a desktop app for building Rayfin apps via chat, wrapping the GitHub Copilot CLI and the Rayfin CLI."
 authors = ["Fabricator"]
 license = "MIT"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Rayfin Fabricator",
-  "version": "0.63.1",
+  "version": "0.63.2",
   "identifier": "com.rayfin.fabricator",
   "build": {
     "frontendDist": "../dist",

--- a/src/renderer/src/components/CreateProjectScreen.test.tsx
+++ b/src/renderer/src/components/CreateProjectScreen.test.tsx
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { act, cleanup, render, screen } from '@testing-library/react'
+import { OverlayProvider } from '../overlay'
+import CreateProjectScreen from './CreateProjectScreen'
+
+/**
+ * Guards issue #2: the Project name field must not let macOS/WebKit auto-correct
+ * or auto-capitalize what the user types (e.g. "app-builder" → "App-builder").
+ * That is controlled by the DOM autocapitalize/autocorrect/spellcheck attributes,
+ * so we assert they are disabled on the input.
+ */
+
+/** Minimal `window.api` surface CreateProjectScreen touches on mount (create mode). */
+function installApi(): void {
+  ;(window as unknown as { api: unknown }).api = {
+    projects: {
+      templates: vi.fn(() => Promise.resolve([])),
+      communityTemplates: vi.fn(() => Promise.resolve({ ok: true, gallery: { templates: [] } })),
+      create: vi.fn(() => Promise.resolve({ ok: true }))
+    },
+    onProcLog: vi.fn(() => () => {}),
+    fabric: { listWorkspaces: vi.fn(() => Promise.resolve({ ok: true, workspaces: [] })) }
+  }
+}
+
+beforeEach(() => {
+  installApi()
+})
+
+afterEach(() => {
+  cleanup()
+  delete (window as unknown as { api?: unknown }).api
+})
+
+describe('CreateProjectScreen project name input', () => {
+  it('disables auto-capitalize / auto-correct / spellcheck so names are typed verbatim (issue #2)', async () => {
+    await act(async () => {
+      render(
+        <OverlayProvider>
+          <CreateProjectScreen
+            mode="create"
+            onCancel={() => {}}
+            onDeploy={() => {}}
+            onContinueWithoutDeploy={() => {}}
+          />
+        </OverlayProvider>
+      )
+    })
+
+    const input = screen.getByPlaceholderText('My Rayfin App')
+    expect(input.getAttribute('autocapitalize')).toBe('off')
+    expect(input.getAttribute('autocorrect')).toBe('off')
+    expect(input.getAttribute('spellcheck')).toBe('false')
+  })
+})

--- a/src/renderer/src/components/CreateProjectScreen.tsx
+++ b/src/renderer/src/components/CreateProjectScreen.tsx
@@ -356,6 +356,9 @@ export default function CreateProjectScreen({
                   value={name}
                   autoFocus
                   placeholder="My Rayfin App"
+                  autoCapitalize="off"
+                  autoCorrect="off"
+                  spellCheck={false}
                   disabled={busy}
                   onChange={(e) => setName(e.target.value)}
                 />


### PR DESCRIPTION
## Summary
Addresses #2 — on macOS the **New Project → Project name** field auto-capitalized and auto-corrected input, so typing `app-builder` became `App-builder`.

## Root cause
The Project name `<input>` in `CreateProjectScreen.tsx` had no autocorrect/autocapitalize controls, so macOS/WebKit applied its default first-letter capitalization and text substitutions. (`spellCheck={false}` alone does not stop capitalization.)

## Fix
Add to the field:
- `autoCapitalize="off"` — the key fix for the reported capitalization
- `autoCorrect="off"` — stops macOS text substitutions
- `spellCheck={false}` — matches the pattern used by the other inputs in this screen

## Tests
Adds `CreateProjectScreen.test.tsx` asserting the input renders with `autocapitalize=off`, `autocorrect=off` and `spellcheck=false`. Verified it **fails** without the fix.

## Validation
- `npm run typecheck` ✅
- `npm run lint` ✅
- `npm test` ✅ (14 tests)

Release: **v0.63.2**.
