### PR TITLE
fix(composer): keep the caret aligned with text in long prompts (#13)

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -8450,6 +8450,13 @@ code {
 .composer-input-sizer {
   display: grid;
   width: 100%;
+  /* The single scrollport for the composer. Both the textarea and the visible
+     highlight layer grow to full content height inside this cell, so scrolling
+     happens here — moving both layers together. This makes caret/text drift
+     structurally impossible (no per-layer scroll to fall out of sync). */
+  max-height: 200px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .composer-input-sizer::after {
@@ -8466,7 +8473,6 @@ code {
   font: inherit;
   line-height: 1.5;
   padding: 4px 0;
-  max-height: 200px;
   white-space: pre-wrap;
   word-break: break-word;
   overflow-wrap: anywhere;
@@ -8483,8 +8489,10 @@ code {
   z-index: 1;
   font: inherit;
   line-height: 1.5;
-  max-height: 200px;
-  overflow-y: auto;
+  /* Grow to full content height; the shared .composer-input-sizer owns the
+     scroll. The textarea must not scroll internally or it would create a second
+     scroll offset that could drift from the highlight overlay. */
+  overflow: hidden;
   padding: 4px 0;
 }
 

--- a/src/renderer/src/components/ChatPanel.test.tsx
+++ b/src/renderer/src/components/ChatPanel.test.tsx
@@ -126,3 +126,92 @@ describe('ChatPanel composer draft', () => {
     expect(ta.value).toBe('')
   })
 })
+
+/**
+ * Guards issue #13: on a long prompt the caret drifted from the typed text
+ * ("typing occurs below the cursor line") because the transparent textarea and
+ * the `.composer-highlight` overlay scrolled independently and were reconciled
+ * only by the textarea's `onScroll`. The composer now shares a single scrollport
+ * (`.composer-input-sizer`) so the two layers can never desync; because the
+ * textarea can no longer scroll internally, ChatPanel scrolls that shared
+ * scrollport itself to keep the caret visible.
+ *
+ * jsdom performs no layout, so real scroll geometry is faked: the scrollport is
+ * made to overflow and the caret's measured rect is stubbed below the viewport.
+ */
+describe('ChatPanel composer scrollport (issue #13)', () => {
+  const rect = (top: number, bottom: number): DOMRect =>
+    ({
+      top,
+      bottom,
+      left: 0,
+      right: 0,
+      width: 1,
+      height: bottom - top,
+      x: 0,
+      y: top,
+      toJSON: () => ({})
+    }) as DOMRect
+
+  it('renders the textarea and highlight overlay inside one shared scrollport', async () => {
+    await act(async () => {
+      render(
+        <ChatPanel project={makeProject('p1')} messages={[]} onChange={() => {}} draft="" />
+      )
+    })
+    const sizer = document.querySelector('.composer-input-sizer')
+    const textarea = document.querySelector('.composer-input')
+    const highlight = document.querySelector('.composer-highlight')
+    expect(sizer).not.toBeNull()
+    expect(textarea).not.toBeNull()
+    expect(highlight).not.toBeNull()
+    // Both visible layers live in the same scroll container — the invariant that
+    // makes caret/text drift structurally impossible.
+    expect(sizer?.contains(textarea)).toBe(true)
+    expect(sizer?.contains(highlight)).toBe(true)
+  })
+
+  it('scrolls the shared scrollport to reveal the caret when a long prompt overflows', async () => {
+    const longPrompt = Array.from({ length: 60 }, (_, i) => `line ${i + 1}`).join('\n')
+    await act(async () => {
+      render(
+        <ChatPanel
+          project={makeProject('p1')}
+          messages={[]}
+          onChange={() => {}}
+          draft={longPrompt}
+        />
+      )
+    })
+    const ta = screen.getByPlaceholderText(PLACEHOLDER) as HTMLTextAreaElement
+    const sizer = document.querySelector('.composer-input-sizer') as HTMLElement
+
+    // Drain the reveal frame queued on mount (it early-returns with no layout),
+    // so the only trigger left is re-entering the field below.
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Fake an overflowing scrollport whose visible band is 100px tall.
+    Object.defineProperty(sizer, 'clientHeight', { value: 100, configurable: true })
+    Object.defineProperty(sizer, 'scrollHeight', { value: 400, configurable: true })
+    sizer.getBoundingClientRect = () => rect(0, 100)
+    // jsdom's Range has no getBoundingClientRect; report the caret ~380px down in
+    // content space (below the visible band) so the reveal has to scroll.
+    const proto = Range.prototype as unknown as { getBoundingClientRect?: () => DOMRect }
+    const origRangeRect = proto.getBoundingClientRect
+    proto.getBoundingClientRect = () => rect(380 - sizer.scrollTop, 396 - sizer.scrollTop)
+
+    sizer.scrollTop = 0
+    ta.setSelectionRange(longPrompt.length, longPrompt.length)
+    // Re-enter the field (the issue's repro) and let the queued frame run.
+    await act(async () => {
+      fireEvent.focus(ta)
+      await new Promise((r) => setTimeout(r, 50))
+    })
+
+    // Scrolled so the caret's bottom (396) sits at the viewport bottom: 396 - 100.
+    expect(sizer.scrollTop).toBe(296)
+    proto.getBoundingClientRect = origRangeRect
+  })
+})

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -1513,9 +1513,91 @@ export default function ChatPanel({
   const pendingCaret = useRef<number | null>(null)
   const taRef = useRef<HTMLTextAreaElement>(null)
   const highlightRef = useRef<HTMLDivElement>(null)
+  const sizerRef = useRef<HTMLDivElement>(null)
+  const revealRaf = useRef<number | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
   const [attaching, setAttaching] = useState(false)
 
+  // Keep the caret in view inside the composer's single scrollport
+  // (`.composer-input-sizer`). The textarea is sized to its full content height so
+  // it never scrolls internally — that is what makes text and the highlight
+  // overlay impossible to desync (issue #13). The trade-off is that the browser no
+  // longer auto-reveals the caret: it only scrolls a control's own scrollport, not
+  // an ancestor. So we nudge the shared scrollport ourselves. This only moves where
+  // that one scrollport sits; both layers live inside it, so they always stay
+  // aligned. The measurement is batched into an animation frame and gated on the
+  // composer actually overflowing, so short prompts pay nothing and fast typing
+  // forces at most one reflow per frame.
+  const revealCaretSoon = useCallback((): void => {
+    if (revealRaf.current != null) return
+    revealRaf.current = requestAnimationFrame(() => {
+      revealRaf.current = null
+      const ta = taRef.current
+      const hl = highlightRef.current
+      const sizer = sizerRef.current
+      if (!ta || !hl || !sizer) return
+      if (sizer.scrollHeight - sizer.clientHeight <= 1) return
+      const caret = ta.selectionEnd ?? ta.value.length
+      // The highlight mirrors the textarea text with identical metrics; mentions
+      // add <mark> children, so walk every text node in order to map the caret
+      // index (into the raw value) onto a DOM position we can measure.
+      const walker = document.createTreeWalker(hl, NodeFilter.SHOW_TEXT)
+      let remaining = caret
+      let node = walker.nextNode()
+      let target: Text | null = null
+      let targetOffset = 0
+      while (node) {
+        const len = node.nodeValue?.length ?? 0
+        if (remaining <= len) {
+          target = node as Text
+          targetOffset = remaining
+          break
+        }
+        remaining -= len
+        const next = walker.nextNode()
+        if (!next) {
+          target = node as Text
+          targetOffset = len
+          break
+        }
+        node = next
+      }
+      if (!target) return
+      const range = document.createRange()
+      range.setStart(target, targetOffset)
+      range.setEnd(target, targetOffset)
+      let rect = range.getBoundingClientRect()
+      if (rect.height === 0) {
+        // A collapsed range can report an empty rect; measure an adjacent glyph.
+        const len = target.nodeValue?.length ?? 0
+        if (targetOffset < len) range.setEnd(target, targetOffset + 1)
+        else if (targetOffset > 0) range.setStart(target, targetOffset - 1)
+        rect = range.getBoundingClientRect()
+      }
+      const sr = sizer.getBoundingClientRect()
+      const top = rect.top - sr.top + sizer.scrollTop
+      const bottom = rect.bottom - sr.top + sizer.scrollTop
+      const viewTop = sizer.scrollTop
+      const viewBottom = viewTop + sizer.clientHeight
+      if (bottom > viewBottom) sizer.scrollTop = bottom - sizer.clientHeight
+      // Snap to the true top when the caret sits on the first line so the field's
+      // top padding shows rather than a sliver-scrolled first line.
+      else if (top < viewTop) sizer.scrollTop = top <= 12 ? 0 : top
+    })
+  }, [])
+
+  // Re-reveal after any value change (typing, paste, @-mention insert) — the
+  // effect runs once the highlight DOM reflects the new text.
+  useEffect(() => {
+    revealCaretSoon()
+  }, [input, revealCaretSoon])
+
+  useEffect(
+    () => () => {
+      if (revealRaf.current != null) cancelAnimationFrame(revealRaf.current)
+    },
+    []
+  )
   const fallbackSuggestions = useMemo(
     () => suggestionsFor(project),
     [project.id, project.name, project.template]
@@ -1701,10 +1783,9 @@ export default function ChatPanel({
   }
 
   // Composer auto-grow is handled purely in CSS via `.composer-input-sizer`
-  // (a hidden replica in the same grid cell). We deliberately avoid a
-  // JS `scrollHeight` measurement here: reading it on every keystroke forced a
-  // synchronous full-page reflow whose cost scaled with the conversation DOM,
-  // producing typing latency that grew with session length.
+  // (a hidden replica in the same grid cell). That container is also the single
+  // scrollport shared by the textarea and the highlight overlay, so the two can
+  // never scroll out of sync; `revealCaretSoon` (above) keeps the caret visible.
 
   // Stage one or more images (from the file picker, paste, or drag-drop) as chat
   // attachments — re-encoded to PNG and saved to a temp file, reusing the same
@@ -2032,6 +2113,7 @@ export default function ChatPanel({
   }
 
   function onComposerSelect(): void {
+    revealCaretSoon()
     if (atDismissed) return
     evalAt()
   }
@@ -2334,7 +2416,7 @@ export default function ChatPanel({
               ))}
             </div>
           )}
-          <div className="composer-input-sizer" data-replicated-value={input}>
+          <div className="composer-input-sizer" ref={sizerRef} data-replicated-value={input}>
             <div className="composer-highlight" ref={highlightRef} aria-hidden="true">
               {splitMentions(input).map((p, i) =>
                 p.mention ? (
@@ -2362,9 +2444,7 @@ export default function ChatPanel({
               onSelect={onComposerSelect}
               onKeyDown={onKeyDown}
               onPaste={onComposerPaste}
-              onScroll={(e) => {
-                if (highlightRef.current) highlightRef.current.scrollTop = e.currentTarget.scrollTop
-              }}
+              onFocus={revealCaretSoon}
             />
           </div>
           <div className="composer-actions">


### PR DESCRIPTION
## Fixes #13 — cursor in the wrong spot when typing a long prompt

### Problem
The chat composer layers a **transparent `<textarea>`** over a `.composer-highlight`
overlay that paints the visible text (and `@`-mention chips). The textarea scrolled
internally (`overflow-y: auto; max-height: 200px`) while the highlight was kept in
sync **only** by the textarea's `onScroll` handler.

Because the two layers scrolled independently, they could drift apart — most reliably
by leaving and re-entering a long, already-scrolled prompt (the browser scrolls the
textarea to reveal the caret, leaving the highlight at a stale offset). The result:
the caret showed on one line while typed text landed on the line **below** it.

### Fix — one shared scrollport (structural)
Both layers now grow to their **full content height** and the wrapping
`.composer-input-sizer` becomes the **single** scrollport. The textarea and the
highlight share one grid cell, so they scroll as a unit and **can never desync** — the
whole class of bug is eliminated by construction. The per-layer `onScroll` sync is
removed.

Since the textarea no longer scrolls internally, the browser stops auto-revealing the
caret (it only scrolls a control's *own* scrollport, not an ancestor — verified in a
headless Chromium probe). `ChatPanel` now nudges the shared scrollport itself to keep
the caret visible, **batched into an animation frame** and **gated on the composer
actually overflowing** so short prompts and fast typing stay cheap.

### Changes
- `src/renderer/src/assets/main.css` — move `max-height`/`overflow` onto
  `.composer-input-sizer`; textarea + highlight grow to content height; textarea set
  to `overflow: hidden`.
- `src/renderer/src/components/ChatPanel.tsx` — remove the `onScroll` highlight sync;
  add an rAF-batched, overflow-gated `revealCaretSoon()` triggered on input / select /
  focus.
- `src/renderer/src/components/ChatPanel.test.tsx` — regression tests: the
  shared-scrollport DOM contract, and the re-entry caret-reveal (fails without the fix).

### Testing
- `npm run typecheck` ✓  `npm run lint` ✓  `npm run test` ✓ (92/92)
- Confirmed the new caret-reveal test **fails** on the pre-fix behavior and **passes**
  with the fix.
- Note: jsdom does no layout, so the reveal geometry is validated with stubbed metrics
  in the unit test and was verified end-to-end in a headless Chromium probe.
