### PR TITLE
Warn when a workspace's region doesn't support Fabric Apps (#16)

### DIFF
--- a/src/renderer/src/components/DeploymentCreateForm.tsx
+++ b/src/renderer/src/components/DeploymentCreateForm.tsx
@@ -5,6 +5,7 @@ import type {
   FabricWorkspace,
   FabricWorkspacesResult
 } from '@shared/ipc'
+import { fabricAppsRegionWarning, FABRIC_REGION_AVAILABILITY_DOC } from '../fabric'
 
 /** Where to send users who have no Fabric/Premium capacity yet. */
 const TRIAL_URL = 'https://learn.microsoft.com/fabric/fundamentals/fabric-trial'
@@ -174,6 +175,8 @@ export default function DeploymentCreateForm({
   // are no eligible workspaces (it's the only list to show) or while searching
   // (matches must be visible since search spans every workspace).
   const ineligibleExpanded = eligible.length === 0 || Boolean(q) || showIneligible
+  const selectedWsRegion = all.find((w) => w.id === selectedWs)?.region
+  const regionWarning = fabricAppsRegionWarning(selectedWsRegion)
 
   function submit(): void {
     if (!selectedWs || running) return
@@ -474,6 +477,19 @@ export default function DeploymentCreateForm({
           </div>
         )}
       </div>
+
+      {regionWarning && (
+        <p className="field-hint field-hint--warn">
+          {regionWarning}{' '}
+          <button
+            type="button"
+            className="ws-create-link"
+            onClick={() => void window.api.openExternal(FABRIC_REGION_AVAILABILITY_DOC)}
+          >
+            View region availability
+          </button>
+        </p>
+      )}
 
       <div className="dep-create-actions">
         {onCancel && (

--- a/src/renderer/src/fabric-apps-unsupported-regions.json
+++ b/src/renderer/src/fabric-apps-unsupported-regions.json
@@ -1,0 +1,12 @@
+{
+  "source": "https://learn.microsoft.com/fabric/admin/region-availability",
+  "verified": "2026-07-20",
+  "note": "Regions where 'Fabric App (preview)' is listed as unavailable in the Fabric region-availability matrix. This is the single place to update when a region gains or loses Fabric Apps support. Preview-scoped: expected to shrink and eventually empty at GA. Values are matched case-insensitively against a workspace's capacity region.",
+  "unsupportedRegions": [
+    "Brazil South",
+    "Canada Central",
+    "North Europe",
+    "South Central US",
+    "West US 3"
+  ]
+}

--- a/src/renderer/src/fabric.test.ts
+++ b/src/renderer/src/fabric.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { fabricWorkspaceUrl } from './fabric'
+import {
+  classifyFabricAppsRegion,
+  fabricAppsRegionWarning,
+  FABRIC_REGION_AVAILABILITY_DOC,
+  fabricWorkspaceUrl,
+} from './fabric'
 
 /**
  * The footer workspace link deep-links to the Fabric portal using the workspace
@@ -28,5 +33,50 @@ describe('fabricWorkspaceUrl', () => {
     expect(fabricWorkspaceUrl(undefined)).toBeUndefined()
     expect(fabricWorkspaceUrl('')).toBeUndefined()
     expect(fabricWorkspaceUrl('   ')).toBeUndefined()
+  })
+})
+
+/**
+ * Fabric Apps (preview) is unavailable in some regions. `classifyFabricAppsRegion`
+ * reads the maintained JSON list and is fail-open (unknown regions never block),
+ * and `fabricAppsRegionWarning` points users at the live docs since availability
+ * changes over time. Real tenant regions are used: West US 3 (unsupported) and
+ * France Central (supported).
+ */
+describe('classifyFabricAppsRegion', () => {
+  it('flags a region listed as unsupported', () => {
+    expect(classifyFabricAppsRegion('West US 3')).toBe('unsupported')
+  })
+
+  it('is case- and whitespace-insensitive', () => {
+    expect(classifyFabricAppsRegion('  west us 3 ')).toBe('unsupported')
+  })
+
+  it('treats a region not in the list as supported', () => {
+    expect(classifyFabricAppsRegion('France Central')).toBe('supported')
+  })
+
+  it('fails open on a missing region', () => {
+    expect(classifyFabricAppsRegion(undefined)).toBe('unknown')
+    expect(classifyFabricAppsRegion('')).toBe('unknown')
+  })
+})
+
+describe('fabricAppsRegionWarning', () => {
+  it('warns and advises checking the docs for an unsupported region', () => {
+    const msg = fabricAppsRegionWarning('West US 3')
+    expect(msg).toContain('West US 3')
+    expect(msg).toContain('documentation')
+  })
+
+  it('returns undefined for supported or unknown regions', () => {
+    expect(fabricAppsRegionWarning('France Central')).toBeUndefined()
+    expect(fabricAppsRegionWarning(undefined)).toBeUndefined()
+  })
+})
+
+describe('FABRIC_REGION_AVAILABILITY_DOC', () => {
+  it('points to the Fabric region-availability matrix', () => {
+    expect(FABRIC_REGION_AVAILABILITY_DOC).toContain('region-availability')
   })
 })

--- a/src/renderer/src/fabric.ts
+++ b/src/renderer/src/fabric.ts
@@ -1,3 +1,5 @@
+import unsupportedRegionsData from './fabric-apps-unsupported-regions.json'
+
 /** Matches a Fabric workspace GUID (the `groups/{id}` segment of a portal URL). */
 const WORKSPACE_GUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
 
@@ -15,4 +17,47 @@ export function fabricWorkspaceUrl(workspaceId?: string): string | undefined {
   const id = workspaceId?.trim()
   if (!id || !WORKSPACE_GUID.test(id)) return undefined
   return `https://app.fabric.microsoft.com/groups/${id}/`
+}
+
+/**
+ * The official Fabric region-availability matrix — the source of truth for which
+ * regions support Fabric Apps. Surfaced in warnings so users can verify the
+ * current list, since availability changes over time (and widens at GA).
+ */
+export const FABRIC_REGION_AVAILABILITY_DOC =
+  'https://learn.microsoft.com/fabric/admin/region-availability'
+
+/**
+ * Regions where Fabric Apps (preview) is unavailable, loaded from
+ * `fabric-apps-unsupported-regions.json` — the single place to update when a
+ * region gains or loses support. Compared case-insensitively.
+ */
+const UNSUPPORTED_FABRIC_APPS_REGIONS = new Set(
+  unsupportedRegionsData.unsupportedRegions.map((r) => r.toLowerCase())
+)
+
+export type FabricAppsRegionSupport = 'supported' | 'unsupported' | 'unknown'
+
+/**
+ * Classify a workspace capacity region for Fabric Apps support. Fail-open: a
+ * missing/unknown region returns 'unknown' and never blocks, so a stale list can
+ * only ever produce a soft warning — never a wrong hard block.
+ */
+export function classifyFabricAppsRegion(
+  region: string | null | undefined
+): FabricAppsRegionSupport {
+  if (!region || !region.trim()) return 'unknown'
+  return UNSUPPORTED_FABRIC_APPS_REGIONS.has(region.trim().toLowerCase())
+    ? 'unsupported'
+    : 'supported'
+}
+
+/**
+ * A user-facing warning when a workspace's region isn't a supported Fabric Apps
+ * region, or undefined when supported/unknown. Advises checking the live docs
+ * because region availability changes over time.
+ */
+export function fabricAppsRegionWarning(region: string | null | undefined): string | undefined {
+  if (classifyFabricAppsRegion(region) !== 'unsupported') return undefined
+  return `The selected workspace is located in ${region}, which is not currently listed as a supported region for Fabric Apps. Region availability changes over time — check the latest supported and unsupported regions in the Fabric documentation before continuing.`
 }


### PR DESCRIPTION


## Problem
Fabric Apps (preview) isn't available in every Fabric region, but the workspace
picker let you select a workspace on an unsupported region and proceed. The
failure only surfaced later during deployment, forcing a teardown and recreate.

## Change
Surface a **fail-open, non-blocking** warning in the shared `DeploymentCreateForm`
(used by both the create-project flow and the deployments popover) when the
selected workspace's capacity region isn't a supported Fabric Apps region. The
message advises checking the docs, with a link to the region-availability matrix,
because availability changes over time (and widens at GA).

## Design notes
- **Fail-open:** an unknown/missing region returns `unknown` and never warns — a
  stale list can only ever produce a soft warning, never a wrong hard block.
- **Non-blocking:** the deploy is left enabled; the platform still performs the
  final validation. This is an early heads-up, not a gate.
- **Maintenance:** the unsupported-region list lives in one JSON file
  (`fabric-apps-unsupported-regions.json`) with a `source` link and `verified`
  date. It's preview-scoped and expected to shrink to empty at GA.
- Considered a runtime doc-scrape and a platform "preflight" of the real deploy
  validation; happy to follow up with the preflight approach (list-free, GA-proof)
  if you'd prefer that direction.

## Changes
- `src/renderer/src/fabric.ts` — `classifyFabricAppsRegion`, `fabricAppsRegionWarning`, `FABRIC_REGION_AVAILABILITY_DOC`
- `src/renderer/src/fabric-apps-unsupported-regions.json` — maintained list (single update point)
- `src/renderer/src/components/DeploymentCreateForm.tsx` — renders the warning + docs link
- `src/renderer/src/fabric.test.ts` — unit tests

## Testing
- `npm run typecheck` — clean
- `npm run lint` — clean
- `npm run build:renderer` — builds
- `npx vitest run src/renderer/src/fabric.test.ts` — 11/11 (real regions: `West US 3` unsupported, `France Central` supported)

## Screenshot
Not included yet — I validated the logic via unit tests and verified typecheck/lint/build.
Happy to build the desktop app and add a screenshot of the warning (selecting a
`West US 3` workspace) if you'd like it before merging.