### PR TITLE
Add "Migrate Power BI Report" flow with report-page capture

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@vscode/codicons": "^0.0.45",
         "highlight.js": "^11.11.1",
         "monaco-editor": "^0.52.2",
+        "pdfjs-dist": "^4.10.38",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-markdown": "^10.1.0",
@@ -1154,6 +1155,271 @@
         "monaco-editor": ">= 0.25.0 < 1",
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@napi-rs/canvas": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas/-/canvas-0.1.100.tgz",
+      "integrity": "sha1-LImhXCimLhNyviP9R0dirhqLFrc=",
+      "license": "MIT",
+      "optional": true,
+      "workspaces": [
+        "e2e/*"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas-android-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-arm64": "0.1.100",
+        "@napi-rs/canvas-darwin-x64": "0.1.100",
+        "@napi-rs/canvas-linux-arm-gnueabihf": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-arm64-musl": "0.1.100",
+        "@napi-rs/canvas-linux-riscv64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-gnu": "0.1.100",
+        "@napi-rs/canvas-linux-x64-musl": "0.1.100",
+        "@napi-rs/canvas-win32-arm64-msvc": "0.1.100",
+        "@napi-rs/canvas-win32-x64-msvc": "0.1.100"
+      }
+    },
+    "node_modules/@napi-rs/canvas-android-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-android-arm64/-/canvas-android-arm64-0.1.100.tgz",
+      "integrity": "sha1-t8aLkdV3AqX8Uj+oLecup0Hmdm4=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-arm64": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-darwin-arm64/-/canvas-darwin-arm64-0.1.100.tgz",
+      "integrity": "sha1-0WhvpsppmwdkDvpfRUJdsKTnJeI=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-darwin-x64": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-darwin-x64/-/canvas-darwin-x64-0.1.100.tgz",
+      "integrity": "sha1-kpeP1+yiH38bWb0TujznwOfIeaE=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm-gnueabihf": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-arm-gnueabihf/-/canvas-linux-arm-gnueabihf-0.1.100.tgz",
+      "integrity": "sha1-lfmJLh1agnSHHY7kBjdOnvaSvZ8=",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-arm64-gnu/-/canvas-linux-arm64-gnu-0.1.100.tgz",
+      "integrity": "sha1-ayt8S7AWuPUwgRWsmukJ30lnqUs=",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-arm64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-arm64-musl/-/canvas-linux-arm64-musl-0.1.100.tgz",
+      "integrity": "sha1-SM9jQlQ+T4fPH46bGqoZrYW8wXg=",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-riscv64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-riscv64-gnu/-/canvas-linux-riscv64-gnu-0.1.100.tgz",
+      "integrity": "sha1-cbARAHsDdVyDSpYXNTAsWDewQdo=",
+      "cpu": [
+        "riscv64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-gnu": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-x64-gnu/-/canvas-linux-x64-gnu-0.1.100.tgz",
+      "integrity": "sha1-P0edO4uMRljl3sG5Q619Lu/SgR8=",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-linux-x64-musl": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-2.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-linux-x64-musl/-/canvas-linux-x64-musl-0.1.100.tgz",
+      "integrity": "sha1-G+rKIsH+l3CanChxFcs8kBlN3sY=",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-arm64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-win32-arm64-msvc/-/canvas-win32-arm64-msvc-0.1.100.tgz",
+      "integrity": "sha1-ihcotFXdF5ZflcC/32dTvoxYUcA=",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/canvas-win32-x64-msvc": {
+      "version": "0.1.100",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/@napi-rs/canvas-win32-x64-msvc/-/canvas-win32-x64-msvc-0.1.100.tgz",
+      "integrity": "sha1-HlKIP4eE/9vlLcLUewWgiGqm6c8=",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5169,6 +5435,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 14.16"
+      }
+    },
+    "node_modules/pdfjs-dist": {
+      "version": "4.10.38",
+      "resolved": "https://ms-feed-12.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/pdfjs-dist/-/pdfjs-dist-4.10.38.tgz",
+      "integrity": "sha1-PuaYADeQ3CZsyLVcDmYsy5rhj1M=",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "@napi-rs/canvas": "^0.1.65"
       }
     },
     "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@vscode/codicons": "^0.0.45",
     "highlight.js": "^11.11.1",
     "monaco-editor": "^0.52.2",
+    "pdfjs-dist": "^4.10.38",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-markdown": "^10.1.0",

--- a/resources/fabricator-templates/fabricator-dataapp/.agents/skills/match-source-report/SKILL.md
+++ b/resources/fabricator-templates/fabricator-dataapp/.agents/skills/match-source-report/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: match-source-report
+description: >
+  Use ONLY when a `source-report/` folder is present in the project — that marks
+  this app as a MIGRATION of an existing Power BI report, not a greenfield build.
+  For a migration the report's existing look IS the design direction: match its
+  palette, typography, layout, and chart types up front. This supersedes the
+  "sensible default theme / defer theming" guidance in build-workflow and
+  app-design. If there is no `source-report/` folder, ignore this skill entirely.
+---
+
+# Match the Source Report
+
+A `source-report/` folder means Fabricator imported an existing Power BI report
+and this app is a **migration** of it. The user already has a look they like — the
+one in the report. Your job is to **rebuild that report as a Rayfin data app that
+looks like the original**, not to invent a fresh aesthetic.
+
+> **This skill only applies when `source-report/` exists.** For a normal
+> greenfield app, it does not apply — follow `build-workflow` / `app-design` as
+> written. A user can turn this behavior off by deleting this skill file (or the
+> `source-report/` folder).
+
+## What overrides what
+
+For a migration, this skill **takes precedence** over the default theming advice:
+
+- `build-workflow` Phase 1 step 5 says *"sensible default theme… do not perfect
+  theming yet."* → **Not for a migration.** The theme is not yours to pick; it's
+  given by the report. Establish it in Phase 1, up front.
+- `app-design` says *"the default kit ships an editorial look… commit to a
+  direction"* and *"Don't theme yet."* → **The direction is already chosen** — it's
+  the source report. Do **not** impose the editorial default; extract the report's
+  direction and match it.
+
+Everything else in `build-workflow` (ship a hero slice, preview every visual
+against live data, iterate) and `visuals` / `dax` / `fabric-data` still applies
+unchanged. This skill only changes *where the design direction comes from* and
+*when you establish it* (up front, not deferred).
+
+## Your inputs (read these first)
+
+| Input | What it is | Use it for |
+|---|---|---|
+| `source-report/pages/page-01.png`, `page-02.png`, … | Each report page rendered as an image | **Primary visual ground truth** — palette, typography, layout grid, spacing, chart types, density. Open every one with your file `view` tool. |
+| `source-report/report.pdf` | The full report export | Higher-fidelity fallback if a page image is unclear. |
+| `source-report/**` (PBIR: `report.json`, pages, visuals) | The report definition | The structural spec — which pages exist, which visuals, their arrangement and roles. |
+| `source-model/**` (TMDL) | The semantic model schema + DAX measures | The data layer — reuse the exact measure names so numbers match. (→ `dax`, `fabric-data`) |
+
+The page images are the reliable visual channel — **look at them directly**. The
+PBIR JSON tells you *what* the visuals are; the images tell you *how they look*.
+
+## Phase 1 for a migration — establish the look, then ship the hero
+
+Do this **before** you settle the hero tile, folding it into the Phase 1 loop:
+
+1. **Study the report.** Open every `source-report/pages/*.png` (fall back to
+   `source-report/report.pdf` if needed). Note, per page:
+   - **Palette** — background, surface, text, and the accent/brand color(s), plus
+     the chart color sequence. Pull approximate hex values from what you see.
+   - **Typography** — serif vs sans vs geometric, heavy vs light, any distinct
+     display face; relative title/label sizes.
+   - **Layout** — the grid, tile sizes and rhythm, KPI band vs charts, density
+     (airy vs packed), alignment.
+   - **Chart types** — bar/line/donut/table/etc., and how they're styled.
+2. **Set the theme tokens up front** in `src/global.css` to match — this is the
+   one place the whole app reads from (→ `app-design`: "Theming"):
+   - `--color-primary` (+ `--color-chart-1`, `--color-ring`, `--color-brand`) to
+     the report's accent family.
+   - `--color-background` / `-card` / `-border` / `-foreground` to the report's
+     canvas + surfaces.
+   - `--color-chart-1..10` to the report's chart color sequence (in order).
+   - `--font-display` / `--font-sans` to the closest match for the report's
+     typography (load via `@fontsource-variable` in `main.tsx` or a Google Fonts
+     `<link>` — → `app-design`: "Typography").
+   - `--radius` to match the report's corner feel (sharp/technical vs soft).
+   Set light values in `@theme static`, dark in `.dark`.
+3. **Then build the hero slice** as usual — but pick the hero visual's *type and
+   placement to mirror the report's most prominent visual*, and preview it against
+   live data (→ `build-workflow` Phase 1, `visuals`, `headless-preview`).
+
+## Phase 2 — breadth that mirrors the report
+
+Recreate the report's pages/visuals: same visual types, same arrangement, same
+KPI band, mapped onto the kit (`StatStrip`, `DashboardGrid` + `Tile`,
+`ChartCard` / `KpiCard` / `DataTableCard`). Reuse the report's DAX measure names
+so the numbers match the original (→ `dax`, `visuals`). Preview each visual.
+
+Fidelity within reason: match the report's **intent** using the Rayfin component
+set — you don't have to pixel-match Power BI chrome, but the palette, typography,
+layout, and chart choices should read as the same report. If Graphein lacks a
+report chart type, re-express it with the closest type (→ `visuals`: Gotchas).
+
+## Final check
+
+Put a `source-report/pages/*.png` next to a preview of your app: same accent
+color? same typographic feel? same layout rhythm and chart types? If someone who
+knew the original opened your app, would they recognize it? If not, adjust the
+`global.css` tokens and layout until they would — then run the normal
+`app-design` Final Audit.

--- a/src-tauri/src/commands/fabric.rs
+++ b/src-tauri/src/commands/fabric.rs
@@ -16,6 +16,7 @@
 use std::cmp::Ordering;
 use std::path::{Path, PathBuf};
 
+use base64::Engine;
 use once_cell::sync::Lazy;
 use regex::Regex;
 use serde::Serialize;
@@ -1134,6 +1135,43 @@ pub async fn fabric_export_report_pdf(
       fail(Some(needs_login), err)
     }
   }
+}
+
+/// Persist the renderer's rasterized report pages (PNG data URLs, one per visible
+/// page) into `<projectDir>/source-report/pages/` as `page-01.png`, `page-02.png`,
+/// … and return their absolute paths. Unlike `screenshot_save` (which writes to a
+/// temp dir the chat turn engine cleans up after the turn), these live in the
+/// project so the build agent can re-open them on *any* turn — the source
+/// report's look is a persistent visual reference for theming, not a one-shot
+/// attachment. `source-report/` is git-ignored, so they're never committed or
+/// bundled. Clears stale pages first so a re-run's numbering stays clean.
+#[tauri::command]
+pub async fn fabric_save_report_pages(
+  project_dir: String,
+  pages: Vec<String>,
+) -> Result<Vec<String>, String> {
+  let dir = PathBuf::from(&project_dir).join("source-report").join("pages");
+  std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+  if let Ok(entries) = std::fs::read_dir(&dir) {
+    for entry in entries.flatten() {
+      let p = entry.path();
+      if p.extension().and_then(|x| x.to_str()) == Some("png") {
+        let _ = std::fs::remove_file(&p);
+      }
+    }
+  }
+  let mut out = Vec::with_capacity(pages.len());
+  for (i, data_url) in pages.iter().enumerate() {
+    // Accept either a `data:image/png;base64,…` URL or a bare base64 string.
+    let b64 = data_url.split_once(',').map(|(_, b)| b).unwrap_or(data_url);
+    let bytes = base64::engine::general_purpose::STANDARD
+      .decode(b64.as_bytes())
+      .map_err(|e| e.to_string())?;
+    let path = dir.join(format!("page-{:02}.png", i + 1));
+    std::fs::write(&path, &bytes).map_err(|e| e.to_string())?;
+    out.push(path.to_string_lossy().to_string());
+  }
+  Ok(out)
 }
 
 /// Node helper that opens the interactive Fabric sign-in / consent window so the

--- a/src-tauri/src/commands/fabric.rs
+++ b/src-tauri/src/commands/fabric.rs
@@ -419,7 +419,7 @@ main().catch((err) => {
 /// Helper executed by the system `node` to export a Power BI report to a PDF via
 /// the Power BI `ExportTo` REST API, then write it to disk and hand it back
 /// base64-encoded (the renderer rasterizes each page to an image with pdf.js).
-/// argv: <authModulePath> <pbiBase> <workspaceId> <reportId> <destPdfPath>.
+/// argv: <pbiBase> <workspaceId> <reportId> <destPdfPath>.
 /// We always export **PDF** (a single file with every page): PNG/image export is
 /// disabled at the tenant level on many tenants, whereas PDF export is broadly
 /// available for capacity-backed workspaces. Writes one JSON line to stdout.
@@ -428,16 +428,42 @@ console.log = (...a) => process.stderr.write(a.map(String).join(' ') + '\n')
 console.debug = console.log
 console.info = console.log
 
-import { pathToFileURL } from 'node:url'
+import { execFile } from 'node:child_process'
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
 const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
 
-// ExportTo lives on the Power BI surface and needs a Power BI-audience token
-// (Report.Read.All). `.default` returns whatever Power BI scopes the Rayfin CLI
-// app is consented for; silentOnly:false lets it pop a one-time consent window.
-const PBI_SCOPES = ['https://analysis.windows.net/powerbi/api/.default']
+// ExportTo lives on the classic Power BI surface and enforces the delegated
+// `Report.Read.All` scope. The Rayfin CLI's MSAL app registration is only
+// consented for Fabric scopes (Item.*/Workspace.*), so its Power BI-audience
+// token is rejected by ExportTo with 401. The Azure CLI's first-party client
+// *is* preauthorized for Power BI (its token carries `scp=user_impersonation`),
+// and `az` is a required, signed-in tool in Fabricator — so, mirroring the
+// DAX/semantic-model path (services/semantic_model_helper.mjs), we mint the
+// ExportTo token via `az` rather than the MSAL Fabric token.
+const PBI_RESOURCE = 'https://analysis.windows.net/powerbi/api'
+
+class NeedsAz extends Error {}
+
+// Acquire a Power BI-audience token from the signed-in Azure CLI. `az` is
+// `az.cmd` on Windows; invoke it through cmd.exe so we don't need shell:true
+// (which Node deprecates when args are passed as an array).
+function azToken(resource) {
+  return new Promise((resolve, reject) => {
+    const args = ['account', 'get-access-token', '--resource', resource, '--query', 'accessToken', '-o', 'tsv']
+    const isWin = process.platform === 'win32'
+    const file = isWin ? process.env.ComSpec || 'cmd.exe' : 'az'
+    const argv = isWin ? ['/d', '/s', '/c', 'az', ...args] : args
+    execFile(file, argv, { windowsHide: true, maxBuffer: 16 * 1024 * 1024 }, (err, stdout, stderr) => {
+      const errText = (stderr || (err && err.message) || '').trim()
+      if (err) return reject(new NeedsAz(errText || 'az account get-access-token failed'))
+      const t = (stdout || '').trim()
+      if (!t) return reject(new NeedsAz(errText || 'az returned no token'))
+      resolve(t)
+    })
+  })
+}
 
 function tag(status, msg) {
   const e = new Error('(' + status + ') ' + msg)
@@ -446,10 +472,8 @@ function tag(status, msg) {
 }
 
 async function main() {
-  const [authPath, pbiBase, workspaceId, reportId, destPath] = process.argv.slice(2)
-  const auth = await import(pathToFileURL(authPath).href)
-  const rf = await auth.getRayfinAuth()
-  const { token } = await rf.acquireToken(PBI_SCOPES, { silentOnly: false })
+  const [pbiBase, workspaceId, reportId, destPath] = process.argv.slice(2)
+  const token = await azToken(PBI_RESOURCE)
   const headers = { Authorization: 'Bearer ' + token }
 
   // 1) Kick off the export.
@@ -503,7 +527,8 @@ async function main() {
 
 main().catch((err) => {
   const msg = err && err.message ? String(err.message) : String(err)
-  const needsLogin = /silent|cached|account|login|token|interactive|sign|unauthorized|forbidden|consent/i.test(msg)
+  const needsLogin = err instanceof NeedsAz ||
+    /silent|cached|account|az login|login|token|interactive|sign|unauthorized|forbidden|consent/i.test(msg)
   process.stdout.write(JSON.stringify({ ok: false, needsLogin, error: msg }))
 })
 "#;
@@ -1006,7 +1031,14 @@ async fn fabric_definition_download(
 
   let out = res.stdout.trim();
   match serde_json::from_str::<FabricReportDefinitionResult>(out) {
-    Ok(parsed) => parsed,
+    Ok(parsed) => {
+      // Keep the downloaded reference definition out of git: it's a migrate-time
+      // spec for the agent, not part of the app the user ships.
+      if parsed.ok {
+        ensure_gitignored(&project_path, &format!("{sub_dir}/"));
+      }
+      parsed
+    }
     Err(_) => {
       let (needs_login, err) = failure_error(&res, out);
       fail(Some(needs_login), err)
@@ -1014,14 +1046,44 @@ async fn fabric_definition_download(
   }
 }
 
-/// Export a Power BI report to a PDF (every page) via the Power BI `ExportTo`
+/// Add `entry` to `<project_dir>/.gitignore` (creating the file if absent) unless
+/// it is already ignored. The migrate flow downloads a report's PBIR into
+/// `source-report/` and its model's TMDL into `source-model/` purely as a spec
+/// for the rebuild agent; those folders (and the exported `report.pdf` inside
+/// `source-report/`) must never be committed or bundled. Best-effort: any I/O
+/// error is swallowed so a hiccup touching `.gitignore` can't fail a download.
+fn ensure_gitignored(project_dir: &Path, entry: &str) {
+  let path = project_dir.join(".gitignore");
+  let existing = std::fs::read_to_string(&path).unwrap_or_default();
+  let bare = entry.trim_end_matches('/');
+  let already = existing
+    .lines()
+    .any(|l| l.trim() == entry || l.trim() == bare);
+  if already {
+    return;
+  }
+  const MARKER: &str = "# Fabricator migrate: downloaded source report/model (reference only)";
+  let mut out = existing;
+  if !out.is_empty() && !out.ends_with('\n') {
+    out.push('\n');
+  }
+  if !out.contains(MARKER) {
+    out.push('\n');
+    out.push_str(MARKER);
+    out.push('\n');
+  }
+  out.push_str(entry);
+  out.push('\n');
+  let _ = std::fs::write(&path, out);
+}
 /// REST API and write it to `<projectDir>/source-report/report.pdf`, returning it
 /// base64-encoded so the renderer can rasterize each page into an image for the
 /// migrate chat hand-off. Best-effort in the migrate flow: image export is
 /// tenant-blocked on many tenants (so we export PDF), and PDF export needs a
 /// capacity-backed workspace — a failure here is surfaced but never blocks the
-/// migration. Runs through the *global* Rayfin CLI so it never waits on the new
-/// project's install; may pop a one-time Power BI consent window.
+/// migration. The ExportTo token comes from the signed-in Azure CLI (`az`), whose
+/// first-party client is preauthorized for Power BI; the Rayfin CLI's own MSAL
+/// token only carries Fabric scopes and is rejected by ExportTo with 401.
 #[tauri::command]
 pub async fn fabric_export_report_pdf(
   workspace_id: String,
@@ -1038,10 +1100,6 @@ pub async fn fabric_export_report_pdf(
   };
 
   let project_path = PathBuf::from(&project_dir);
-  let auth_path = match project_auth_module(None).await {
-    Ok(p) => p,
-    Err(error) => return fail(None, error),
-  };
 
   let script_path = match write_helper("fabric-export-pdf.mjs", EXPORT_PDF_HELPER_SOURCE) {
     Ok(p) => p,
@@ -1049,14 +1107,12 @@ pub async fn fabric_export_report_pdf(
   };
 
   let dest = project_path.join("source-report").join("report.pdf");
-  let auth_str = auth_path.to_string_lossy().to_string();
   let script_str = script_path.to_string_lossy().to_string();
   let dest_str = dest.to_string_lossy().to_string();
   let res = exec::run(
     "node",
     &[
       &script_str,
-      &auth_str,
       FABRIC_PBI_BASE,
       &workspace_id,
       &report_id,
@@ -1581,13 +1637,44 @@ mod tests {
     // The migrate "capture pages" sub-step exports a PDF (image export is
     // tenant-blocked on many tenants) via the Power BI ExportTo API, polls the
     // long-running op, and returns the file base64 for renderer rasterization.
-    assert!(EXPORT_PDF_HELPER_SOURCE.contains("getRayfinAuth"));
-    assert!(EXPORT_PDF_HELPER_SOURCE.contains("analysis.windows.net/powerbi/api/.default"));
+    // The ExportTo token is minted via `az` (the Rayfin CLI's MSAL token only
+    // carries Fabric scopes and is rejected by ExportTo with 401).
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("account', 'get-access-token"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("analysis.windows.net/powerbi/api"));
+    assert!(!EXPORT_PDF_HELPER_SOURCE.contains("getRayfinAuth"));
     assert!(EXPORT_PDF_HELPER_SOURCE.contains("/ExportTo"));
     assert!(EXPORT_PDF_HELPER_SOURCE.contains("format: 'PDF'"));
     assert!(EXPORT_PDF_HELPER_SOURCE.contains("Succeeded"));
     assert!(EXPORT_PDF_HELPER_SOURCE.contains("pdfBase64"));
     // Power BI-audience base, distinct from the Fabric API base.
     assert_eq!(FABRIC_PBI_BASE, "https://api.powerbi.com/v1.0/myorg");
+  }
+
+  #[test]
+  fn ensure_gitignored_appends_once_and_is_idempotent() {
+    let dir = std::env::temp_dir().join(format!("fab-gi-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
+    std::fs::create_dir_all(&dir).unwrap();
+    let gi = dir.join(".gitignore");
+    std::fs::write(&gi, "node_modules\ndist\n").unwrap();
+
+    ensure_gitignored(&dir, "source-report/");
+    ensure_gitignored(&dir, "source-model/");
+    // Repeat calls (and the bare form) must not duplicate entries.
+    ensure_gitignored(&dir, "source-report/");
+    ensure_gitignored(&dir, "source-model");
+
+    let body = std::fs::read_to_string(&gi).unwrap();
+    assert_eq!(body.matches("source-report/").count(), 1, "report ignore once");
+    assert_eq!(body.matches("source-model/").count(), 1, "model ignore once");
+    assert!(body.contains("node_modules"), "preserves existing entries");
+
+    // Creates the file when absent.
+    let dir2 = dir.join("nested");
+    std::fs::create_dir_all(&dir2).unwrap();
+    ensure_gitignored(&dir2, "source-report/");
+    assert!(std::fs::read_to_string(dir2.join(".gitignore")).unwrap().contains("source-report/"));
+
+    let _ = std::fs::remove_dir_all(&dir);
   }
 }

--- a/src-tauri/src/commands/fabric.rs
+++ b/src-tauri/src/commands/fabric.rs
@@ -22,10 +22,17 @@ use serde::Serialize;
 
 use crate::services::{exec, paths, store};
 use crate::services::exec::RunOptions;
-use crate::types::{FabricDeleteResult, FabricWorkspacesResult};
-use crate::types::{FabricCapacitiesResult, FabricCreateWorkspaceResult};
+use crate::types::{
+  FabricDeleteResult, FabricReportDefinitionResult, FabricReportsResult, FabricSignInResult,
+  FabricWorkspacesResult,
+};
+use crate::types::{FabricCapacitiesResult, FabricCreateWorkspaceResult, FabricExportPdfResult};
 
 const FABRIC_API_BASE: &str = "https://api.fabric.microsoft.com/v1";
+
+/// Power BI REST base. The report export-to-file API (`ExportTo`) lives on the
+/// Power BI surface (not the Fabric one), so it needs a Power BI-audience token.
+const FABRIC_PBI_BASE: &str = "https://api.powerbi.com/v1.0/myorg";
 
 /// `ok:false` parse-failure paths classify the error as a login problem with
 /// the same heuristic the TS used (note: no `interactive` here, matching
@@ -137,6 +144,366 @@ async function main() {
 main().catch((err) => {
   const msg = err && err.message ? String(err.message) : String(err)
   const needsLogin = /silent|cached|account|login|token|interactive|sign/i.test(msg)
+  process.stdout.write(JSON.stringify({ ok: false, needsLogin, error: msg }))
+})
+"#;
+
+/// Helper executed by the system `node` to list a workspace's Power BI reports.
+/// argv: <authModulePath> <apiBase> <workspaceId>. Writes exactly one JSON line
+/// to stdout; library logging is routed to stderr.
+const REPORTS_HELPER_SOURCE: &str = r#"// Keep stdout clean for the JSON result; route any library logging to stderr.
+console.log = (...a) => process.stderr.write(a.map(String).join(' ') + '\n')
+console.debug = console.log
+console.info = console.log
+
+import { pathToFileURL } from 'node:url'
+
+const API_HOST = 'https://api.fabric.microsoft.com'
+
+// Reports list endpoint pages at 100 items each, returning a continuationUri /
+// continuationToken when more remain. Follow every page so nothing is lost.
+async function fetchAllPages(startUrl, headers, { label = '' } = {}) {
+  const out = []
+  const seen = new Set()
+  let url = startUrl
+  for (let i = 0; i < 100 && url; i++) {
+    if (seen.has(url)) break
+    seen.add(url)
+    const res = await fetch(url, { headers })
+    if (!res.ok) {
+      throw new Error('Fabric ' + (label || startUrl) + ' request failed (' + res.status + ')')
+    }
+    const json = await res.json()
+    for (const v of json.value || []) out.push(v)
+    if (json.continuationUri) {
+      url = json.continuationUri.startsWith('http') ? json.continuationUri : API_HOST + json.continuationUri
+    } else if (json.continuationToken) {
+      url = startUrl + (startUrl.includes('?') ? '&' : '?') + '$continuationToken=' + encodeURIComponent(json.continuationToken)
+    } else {
+      url = null
+    }
+  }
+  return out
+}
+
+async function main() {
+  const [authPath, base, workspaceId] = process.argv.slice(2)
+  const auth = await import(pathToFileURL(authPath).href)
+  const rf = await auth.getRayfinAuth()
+  // silentOnly: never pop a browser — fail fast if there's no cached session.
+  const { token } = await rf.acquireToken(undefined, { silentOnly: true })
+  const headers = { Authorization: 'Bearer ' + token }
+
+  const value = await fetchAllPages(
+    base + '/workspaces/' + encodeURIComponent(workspaceId) + '/reports',
+    headers,
+    { label: '/reports' }
+  )
+  const reports = value.map((r) => ({
+    id: r.id,
+    displayName: r.displayName || r.name || r.id,
+    description: r.description || undefined,
+    webUrl: r.webUrl || undefined
+  }))
+  process.stdout.write(JSON.stringify({ ok: true, reports }))
+}
+
+main().catch((err) => {
+  const msg = err && err.message ? String(err.message) : String(err)
+  const needsLogin = /silent|cached|account|login|token|interactive|sign/i.test(msg)
+  process.stdout.write(JSON.stringify({ ok: false, needsLogin, error: msg }))
+})
+"#;
+
+/// Helper executed by the system `node` to download an item's public definition
+/// and write each part to disk. argv:
+/// <authModulePath> <apiBase> <mode> <workspaceId> <itemId> <destDir>, where
+/// `mode` is `report` (PBIR → also returns the bound `modelId`) or `model`
+/// (semantic model TMDL). Follows the Fabric long-running-operation protocol and
+/// base64-decodes each inline part.
+const DEFINITION_HELPER_SOURCE: &str = r#"// Keep stdout clean for the JSON result; route any library logging to stderr.
+console.log = (...a) => process.stderr.write(a.map(String).join(' ') + '\n')
+console.debug = console.log
+console.info = console.log
+
+import { pathToFileURL } from 'node:url'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+// getDefinition returns editable report code, so it needs a Fabric *write* scope
+// (Item.ReadWrite.All). Only this migrate flow asks for it — read-only users
+// never trigger it — so we request it here rather than widening the app's
+// baseline sign-in. acquireToken tries the cached session first and only opens an
+// interactive consent window when this scope hasn't been granted yet.
+const WRITE_SCOPES = ['https://api.fabric.microsoft.com/Item.ReadWrite.All']
+
+// Request an item's public definition. getDefinition is a long-running
+// operation: a 202 hands back a Location to poll until the operation settles,
+// at which point the result carries `definition.parts` (either inline on the
+// status body or at the operation's `/result` endpoint). `itemType` is the
+// Fabric collection segment — `reports` or `semanticModels`.
+async function requestDefinition(base, wsId, itemType, itemId, headers, format) {
+  const q = format ? '?format=' + encodeURIComponent(format) : ''
+  const startUrl =
+    base + '/workspaces/' + encodeURIComponent(wsId) +
+    '/' + itemType + '/' + encodeURIComponent(itemId) + '/getDefinition' + q
+  const res = await fetch(startUrl, { method: 'POST', headers })
+
+  if (res.status === 202) {
+    const loc = res.headers.get('location')
+    let retry = Number(res.headers.get('retry-after')) || 2
+    if (!loc) throw new Error('getDefinition was accepted but returned no polling Location')
+    for (let i = 0; i < 120; i++) {
+      await sleep(retry * 1000)
+      const poll = await fetch(loc, { headers })
+      if (!poll.ok) {
+        const t = await poll.text().catch(() => '')
+        throw new Error('getDefinition polling failed (' + poll.status + ') ' + t.slice(0, 200))
+      }
+      const body = await poll.json().catch(() => ({}))
+      retry = Number(poll.headers.get('retry-after')) || retry
+      const status = String(body.status || '').toLowerCase()
+      if (status === 'failed') {
+        throw new Error((body.error && body.error.message) || 'getDefinition operation failed')
+      }
+      if (body.definition) return body.definition
+      if (status === 'succeeded') {
+        const resultUrl = loc.replace(/\/$/, '') + '/result'
+        const r = await fetch(resultUrl, { headers })
+        if (!r.ok) {
+          const t = await r.text().catch(() => '')
+          throw new Error('getDefinition result fetch failed (' + r.status + ') ' + t.slice(0, 200))
+        }
+        return (await r.json()).definition
+      }
+      // Otherwise still Running / NotStarted — keep polling.
+    }
+    throw new Error('getDefinition timed out waiting for the operation to complete')
+  }
+
+  if (!res.ok) {
+    const t = await res.text().catch(() => '')
+    const err = new Error('getDefinition failed (' + res.status + ') ' + t.slice(0, 200))
+    err.status = res.status
+    throw err
+  }
+  return (await res.json()).definition
+}
+
+// Fetch an item's definition with a given bearer token, trying each format in
+// order and returning the first that succeeds. `formats` is an ordered list of
+// preferred → fallback formats (use `undefined` for "the item's stored format").
+// A report authored in the classic format can't be converted to enhanced PBIR:
+// getDefinition accepts the request (202) and then *fails the long-running
+// operation* with "cannot be converted", so we must fall through to PBIR-Legacy.
+// Auth/consent failures are surfaced immediately rather than masked by a retry.
+async function getDefinitionWith(base, wsId, itemType, itemId, token, formats) {
+  const headers = { Authorization: 'Bearer ' + token }
+  let lastErr
+  for (const fmt of formats) {
+    try {
+      return await requestDefinition(base, wsId, itemType, itemId, headers, fmt)
+    } catch (e) {
+      lastErr = e
+      const status = e && e.status
+      const msg = String((e && e.message) || '')
+      const isAuth =
+        status === 401 ||
+        status === 403 ||
+        /unauthorized|forbidden|consent|\btoken\b|sign in|\blogin\b/i.test(msg)
+      if (isAuth) throw e
+      // Otherwise it's a format/availability problem — try the next format.
+    }
+  }
+  throw lastErr
+}
+
+// Base64-decode each inline part and write it under destDir, returning the list
+// of relative paths written.
+function writeParts(parts, destDir) {
+  const files = []
+  for (const p of parts || []) {
+    if (!p || !p.path) continue
+    const abs = join(destDir, p.path)
+    mkdirSync(dirname(abs), { recursive: true })
+    const buf =
+      p.payloadType === 'InlineBase64' && typeof p.payload === 'string'
+        ? Buffer.from(p.payload, 'base64')
+        : Buffer.from(String(p.payload == null ? '' : p.payload), 'utf8')
+    writeFileSync(abs, buf)
+    files.push(p.path)
+  }
+  return files
+}
+
+// A thin report binds to its semantic model by a live connection. Both PBIR and
+// PBIR-Legacy expose a `definition.pbir` whose `datasetReference` carries that
+// binding; the model's dataset GUID (which equals the semantic model's Fabric
+// item id) shows up as a `semanticmodelid=` param on the `byConnection`
+// connection string (the modern PBIR v4 format — note its `initial catalog=` is
+// the model *name*, not a GUID), as `pbiModelDatabaseName`, as an
+// `Initial Catalog=<GUID>` connection string, or as a `datasetId`. Search the
+// pbir first, then fall back to every part (legacy report.json, connections
+// files, …) so we resolve the model that actually holds the DAX regardless of
+// the report's stored format.
+function decodePart(p) {
+  try {
+    return p && p.payloadType === 'InlineBase64' && typeof p.payload === 'string'
+      ? Buffer.from(p.payload, 'base64').toString('utf8')
+      : String((p && p.payload) || '')
+  } catch {
+    return ''
+  }
+}
+
+function resolveModelId(parts) {
+  const list = parts || []
+  const GUID = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}'
+  const find = (text) => {
+    if (!text) return null
+    const m =
+      text.match(new RegExp('semanticmodelid\\s*=\\s*(' + GUID + ')', 'i')) ||
+      text.match(new RegExp('"pbiModelDatabaseName"\\s*:\\s*"(' + GUID + ')"')) ||
+      text.match(new RegExp('Initial Catalog=(' + GUID + ')', 'i')) ||
+      text.match(new RegExp('"datasetId"\\s*:\\s*"(' + GUID + ')"', 'i'))
+    return m ? m[1] : null
+  }
+  const pbir = list.find(
+    (p) => p && typeof p.path === 'string' && /(^|\/)definition\.pbir$/i.test(p.path)
+  )
+  return find(pbir ? decodePart(pbir) : null) || find(list.map(decodePart).join('\n'))
+}
+
+async function main() {
+  const [authPath, base, mode, workspaceId, itemId, destDir] = process.argv.slice(2)
+  const auth = await import(pathToFileURL(authPath).href)
+  const rf = await auth.getRayfinAuth()
+
+  // silentOnly:false → reuse the cached session when it already carries the write
+  // scope, otherwise pop an interactive consent window to request it. This download
+  // is the only place the migrate flow asks for write access, so read-only users
+  // never trigger a consent prompt.
+  const { token } = await rf.acquireToken(WRITE_SCOPES, { silentOnly: false })
+
+  if (mode === 'model') {
+    // The semantic model holds the real DAX measures/tables/relationships. TMDL
+    // is the human-readable format; fall back to the stored (TMSL) format.
+    const modelDef = await getDefinitionWith(base, workspaceId, 'semanticModels', itemId, token, ['TMDL', undefined])
+    const files = writeParts((modelDef && modelDef.parts) || [], destDir)
+    process.stdout.write(JSON.stringify({ ok: true, files, dir: destDir }))
+    return
+  }
+
+  // Default: report mode. PBIR gives pages/visuals as split files; classic
+  // reports can't convert to PBIR, so fall back to PBIR-Legacy (report.json).
+  // Also resolve the bound semantic model id so the caller can download the
+  // model (the DAX) as a separate step.
+  const definition = await getDefinitionWith(base, workspaceId, 'reports', itemId, token, ['PBIR', 'PBIR-Legacy'])
+  const parts = (definition && definition.parts) || []
+  const files = writeParts(parts, destDir)
+  const modelId = resolveModelId(parts)
+  const result = { ok: true, files, dir: destDir }
+  if (modelId) result.modelId = modelId
+  process.stdout.write(JSON.stringify(result))
+}
+
+main().catch((err) => {
+  const msg = err && err.message ? String(err.message) : String(err)
+  const needsLogin = /silent|cached|account|login|token|interactive|sign|unauthorized|forbidden|consent/i.test(msg)
+  process.stdout.write(JSON.stringify({ ok: false, needsLogin, error: msg }))
+})
+"#;
+
+/// Helper executed by the system `node` to export a Power BI report to a PDF via
+/// the Power BI `ExportTo` REST API, then write it to disk and hand it back
+/// base64-encoded (the renderer rasterizes each page to an image with pdf.js).
+/// argv: <authModulePath> <pbiBase> <workspaceId> <reportId> <destPdfPath>.
+/// We always export **PDF** (a single file with every page): PNG/image export is
+/// disabled at the tenant level on many tenants, whereas PDF export is broadly
+/// available for capacity-backed workspaces. Writes one JSON line to stdout.
+const EXPORT_PDF_HELPER_SOURCE: &str = r#"// Keep stdout clean for the JSON result; route any library logging to stderr.
+console.log = (...a) => process.stderr.write(a.map(String).join(' ') + '\n')
+console.debug = console.log
+console.info = console.log
+
+import { pathToFileURL } from 'node:url'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { dirname } from 'node:path'
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms))
+
+// ExportTo lives on the Power BI surface and needs a Power BI-audience token
+// (Report.Read.All). `.default` returns whatever Power BI scopes the Rayfin CLI
+// app is consented for; silentOnly:false lets it pop a one-time consent window.
+const PBI_SCOPES = ['https://analysis.windows.net/powerbi/api/.default']
+
+function tag(status, msg) {
+  const e = new Error('(' + status + ') ' + msg)
+  e.status = status
+  return e
+}
+
+async function main() {
+  const [authPath, pbiBase, workspaceId, reportId, destPath] = process.argv.slice(2)
+  const auth = await import(pathToFileURL(authPath).href)
+  const rf = await auth.getRayfinAuth()
+  const { token } = await rf.acquireToken(PBI_SCOPES, { silentOnly: false })
+  const headers = { Authorization: 'Bearer ' + token }
+
+  // 1) Kick off the export.
+  const startUrl =
+    pbiBase + '/groups/' + encodeURIComponent(workspaceId) +
+    '/reports/' + encodeURIComponent(reportId) + '/ExportTo'
+  const start = await fetch(startUrl, {
+    method: 'POST',
+    headers: { ...headers, 'Content-Type': 'application/json' },
+    body: JSON.stringify({ format: 'PDF' })
+  })
+  if (!start.ok) {
+    const t = await start.text().catch(() => '')
+    throw tag(start.status, 'ExportTo start failed: ' + t.slice(0, 300))
+  }
+  const exportId = (await start.json()).id
+  if (!exportId) throw new Error('ExportTo returned no export id')
+
+  // 2) Poll the long-running export until it settles.
+  const statusUrl =
+    pbiBase + '/groups/' + encodeURIComponent(workspaceId) +
+    '/reports/' + encodeURIComponent(reportId) + '/exports/' + encodeURIComponent(exportId)
+  let state = 'Running'
+  for (let i = 0; i < 150; i++) {
+    await sleep(2000)
+    const p = await fetch(statusUrl, { headers })
+    if (!p.ok) {
+      const t = await p.text().catch(() => '')
+      throw tag(p.status, 'export polling failed: ' + t.slice(0, 200))
+    }
+    const body = await p.json().catch(() => ({}))
+    state = String(body.status || '')
+    if (state === 'Succeeded' || state === 'Failed') break
+  }
+  if (state !== 'Succeeded') throw new Error('report export did not succeed (status: ' + state + ')')
+
+  // 3) Download the PDF, persist it, and return it inline for rasterization.
+  const dl = await fetch(statusUrl + '/file', { headers })
+  if (!dl.ok) {
+    const t = await dl.text().catch(() => '')
+    throw tag(dl.status, 'export download failed: ' + t.slice(0, 200))
+  }
+  const buf = Buffer.from(await dl.arrayBuffer())
+  mkdirSync(dirname(destPath), { recursive: true })
+  writeFileSync(destPath, buf)
+
+  process.stdout.write(JSON.stringify({
+    ok: true, pdfPath: destPath, bytes: buf.length, pdfBase64: buf.toString('base64')
+  }))
+}
+
+main().catch((err) => {
+  const msg = err && err.message ? String(err.message) : String(err)
+  const needsLogin = /silent|cached|account|login|token|interactive|sign|unauthorized|forbidden|consent/i.test(msg)
   process.stdout.write(JSON.stringify({ ok: false, needsLogin, error: msg }))
 })
 "#;
@@ -315,16 +682,95 @@ fn failure_error(res: &exec::RunResult, out: &str) -> (bool, String) {
   (needs_login, err)
 }
 
-/// Resolve the active project's local CLI auth module, restoring dependencies
-/// first when a clone or manually opened project has no node_modules yet.
+/// Resolve a Fabric auth module for REST calls. Prefers the project's local CLI
+/// when it's *already* installed, otherwise falls back to the globally-installed
+/// `rayfin` CLI. It never triggers an `npm install`: Fabric calls only need a
+/// bearer token, and the MSAL session cache is shared between the local and global
+/// CLIs, so the signed-in session is always reachable via the global CLI. Forcing a
+/// dependency install here previously made every Fabric command (workspace/report
+/// listing, migrate downloads, sign-in) hang behind a long — and, on locked-down
+/// npm feeds, failing — install whenever the active project's deps weren't restored.
 async fn project_auth_module(project_dir: Option<&Path>) -> Result<PathBuf, String> {
-  if let Some(dir) = project_dir {
-    exec::ensure_project_dependencies(dir, None)
-      .await
-      .map_err(|error| format!("Could not install this project's dependencies: {error}"))?;
-  }
-  exec::project_rayfin_auth_module(project_dir).ok_or_else(|| {
+  let local_ready = project_dir.is_some_and(exec::project_rayfin_cli_installed);
+  let resolved = if local_ready { project_dir } else { None };
+  exec::project_rayfin_auth_module(resolved).ok_or_else(|| {
     "Could not locate the Rayfin CLI. Open a Rayfin project to reach Fabric.".to_string()
+  })
+}
+
+/// A node child that couldn't *load* its auth module — a broken or partial
+/// `node_modules` (e.g. a version-mismatched `@azure/msal-node`) — rather than a
+/// genuine auth/API failure. The helper catches the failed dynamic `import()`
+/// into its JSON, so this signature can appear on stdout as well as stderr.
+static MODULE_LOAD_FAILURE_RE: Lazy<Regex> = Lazy::new(|| {
+  Regex::new(r"(?i)cannot find (module|package)|err_module_not_found|err_package_path_not_exported")
+    .unwrap()
+});
+
+/// True when a helper run failed because node couldn't resolve/load the auth
+/// module graph (checked across stdout — the helper catches the import error into
+/// its JSON — and stderr, for the uncaught case).
+fn is_module_load_failure(res: &exec::RunResult) -> bool {
+  MODULE_LOAD_FAILURE_RE.is_match(&res.stdout) || MODULE_LOAD_FAILURE_RE.is_match(&res.stderr)
+}
+
+/// Ordered auth-module candidates for account-level Fabric calls (workspaces,
+/// reports, sign-in): the active project's local CLI first (when installed, to
+/// honor its pinned version), then the global CLI as a fallback. Never installs.
+/// The MSAL token cache is shared across installs, so every candidate reaches the
+/// same signed-in session — retrying the global module simply routes around a
+/// broken/partial project-local `node_modules` instead of surfacing a cryptic
+/// "Cannot find module" to the user.
+fn account_auth_modules() -> Vec<PathBuf> {
+  let project_dir = store::active_project().map(|p| PathBuf::from(p.path));
+  let local_ready = project_dir
+    .as_deref()
+    .is_some_and(exec::project_rayfin_cli_installed);
+  let preferred = if local_ready { project_dir.as_deref() } else { None };
+
+  let mut mods = Vec::new();
+  if let Some(m) = exec::project_rayfin_auth_module(preferred) {
+    mods.push(m);
+  }
+  if let Some(global) = exec::global_rayfin_auth_module() {
+    if !mods.contains(&global) {
+      mods.push(global);
+    }
+  }
+  mods
+}
+
+/// Run a Fabric node helper against each candidate auth module until one loads,
+/// returning that child's [`exec::RunResult`]. `base_args` are the argv *after*
+/// the auth-module path. A candidate that only failed to load is skipped when a
+/// later one remains; any other outcome (success, a real auth/API error, or
+/// node-not-found) is returned as-is. Callers must pass a non-empty candidate list.
+async fn run_fabric_helper(
+  script_str: &str,
+  base_args: &[&str],
+  timeout_ms: u64,
+  candidates: &[PathBuf],
+) -> exec::RunResult {
+  let n = candidates.len();
+  let mut last: Option<exec::RunResult> = None;
+  for (i, auth) in candidates.iter().enumerate() {
+    let auth_str = auth.to_string_lossy().to_string();
+    let mut argv: Vec<&str> = Vec::with_capacity(2 + base_args.len());
+    argv.push(script_str);
+    argv.push(&auth_str);
+    argv.extend_from_slice(base_args);
+    let res = exec::run("node", &argv, RunOptions::timeout(timeout_ms)).await;
+    if i + 1 == n || res.not_found || !is_module_load_failure(&res) {
+      return res;
+    }
+    last = Some(res);
+  }
+  last.unwrap_or(exec::RunResult {
+    ok: false,
+    exit_code: None,
+    stdout: String::new(),
+    stderr: "Could not locate the Rayfin CLI. Open a Rayfin project to reach Fabric.".to_string(),
+    not_found: true,
   })
 }
 
@@ -332,18 +778,17 @@ async fn project_auth_module(project_dir: Option<&Path>) -> Result<PathBuf, Stri
 /// capacity SKU and whether that capacity is eligible to host a Rayfin app.
 #[tauri::command]
 pub async fn fabric_workspaces() -> FabricWorkspacesResult {
-  let project_dir = store::active_project().map(|p| PathBuf::from(p.path));
-  let auth_path = match project_auth_module(project_dir.as_deref()).await {
-    Ok(p) => p,
-    Err(error) => {
-      return FabricWorkspacesResult {
-        ok: false,
-        workspaces: None,
-        needs_login: None,
-        error: Some(error),
-      }
-    }
-  };
+  let candidates = account_auth_modules();
+  if candidates.is_empty() {
+    return FabricWorkspacesResult {
+      ok: false,
+      workspaces: None,
+      needs_login: None,
+      error: Some(
+        "Could not locate the Rayfin CLI. Open a Rayfin project to reach Fabric.".to_string(),
+      ),
+    };
+  }
 
   let script_path = match write_helper("fabric-workspaces.mjs", HELPER_SOURCE) {
     Ok(p) => p,
@@ -357,14 +802,8 @@ pub async fn fabric_workspaces() -> FabricWorkspacesResult {
     }
   };
 
-  let auth_str = auth_path.to_string_lossy().to_string();
   let script_str = script_path.to_string_lossy().to_string();
-  let res = exec::run(
-    "node",
-    &[&script_str, &auth_str, FABRIC_API_BASE],
-    RunOptions::timeout(60_000),
-  )
-  .await;
+  let res = run_fabric_helper(&script_str, &[FABRIC_API_BASE], 60_000, &candidates).await;
 
   if res.not_found {
     return FabricWorkspacesResult {
@@ -404,6 +843,313 @@ pub async fn fabric_workspaces() -> FabricWorkspacesResult {
         ok: false,
         workspaces: None,
         needs_login: Some(needs_login),
+        error: Some(err),
+      }
+    }
+  }
+}
+
+/// List the Power BI reports contained in a Fabric workspace so the user can
+/// pick one to migrate. Mirrors `fabric_workspaces`, passing the workspace id
+/// to the helper as an extra argv and sorting the result alphabetically.
+#[tauri::command]
+pub async fn fabric_reports(workspace_id: String) -> FabricReportsResult {
+  let candidates = account_auth_modules();
+  if candidates.is_empty() {
+    return FabricReportsResult {
+      ok: false,
+      reports: None,
+      needs_login: None,
+      error: Some(
+        "Could not locate the Rayfin CLI. Open a Rayfin project to reach Fabric.".to_string(),
+      ),
+    };
+  }
+
+  let script_path = match write_helper("fabric-reports.mjs", REPORTS_HELPER_SOURCE) {
+    Ok(p) => p,
+    Err(err) => {
+      return FabricReportsResult {
+        ok: false,
+        reports: None,
+        needs_login: None,
+        error: Some(format!("Could not prepare the report lookup helper: {err}")),
+      }
+    }
+  };
+
+  let script_str = script_path.to_string_lossy().to_string();
+  let res = run_fabric_helper(
+    &script_str,
+    &[FABRIC_API_BASE, &workspace_id],
+    60_000,
+    &candidates,
+  )
+  .await;
+
+  if res.not_found {
+    return FabricReportsResult {
+      ok: false,
+      reports: None,
+      needs_login: None,
+      error: Some("Node.js was not found on PATH.".to_string()),
+    };
+  }
+
+  let out = res.stdout.trim();
+  match serde_json::from_str::<FabricReportsResult>(out) {
+    Ok(mut parsed) => {
+      if parsed.ok {
+        if let Some(reports) = parsed.reports.as_mut() {
+          reports.sort_by(|a, b| {
+            a.display_name
+              .to_lowercase()
+              .cmp(&b.display_name.to_lowercase())
+          });
+        }
+      }
+      parsed
+    }
+    Err(_) => {
+      let (needs_login, err) = failure_error(&res, out);
+      FabricReportsResult {
+        ok: false,
+        reports: None,
+        needs_login: Some(needs_login),
+        error: Some(err),
+      }
+    }
+  }
+}
+
+/// Download a report's public definition (PBIR) into `<projectDir>/source-report`
+/// so the agent can rebuild it, and resolve the id of the semantic model the
+/// report is bound to (returned as `modelId`) so the caller can download the
+/// model as a separate step. The node child follows the getDefinition LRO and
+/// base64-decodes each part.
+#[tauri::command]
+pub async fn fabric_report_definition(
+  workspace_id: String,
+  report_id: String,
+  project_dir: String,
+) -> FabricReportDefinitionResult {
+  fabric_definition_download("report", &workspace_id, &report_id, &project_dir, "source-report").await
+}
+
+/// Download a semantic model's definition (TMDL — where the DAX measures live)
+/// into `<projectDir>/source-model`. `model_id` comes from a prior
+/// `fabric_report_definition` call. Best-effort in the UI: a failure here (e.g. a
+/// cross-workspace model) is surfaced but never blocks the report migration.
+#[tauri::command]
+pub async fn fabric_semantic_model_definition(
+  workspace_id: String,
+  model_id: String,
+  project_dir: String,
+) -> FabricReportDefinitionResult {
+  fabric_definition_download("model", &workspace_id, &model_id, &project_dir, "source-model").await
+}
+
+/// Shared driver for the report/model getDefinition downloads. Runs the
+/// mode-aware node helper, writing parts under `<projectDir>/<sub_dir>`.
+async fn fabric_definition_download(
+  mode: &str,
+  workspace_id: &str,
+  item_id: &str,
+  project_dir: &str,
+  sub_dir: &str,
+) -> FabricReportDefinitionResult {
+  let fail = |needs_login: Option<bool>, error: String| FabricReportDefinitionResult {
+    ok: false,
+    files: None,
+    dir: None,
+    model_id: None,
+    needs_login,
+    error: Some(error),
+  };
+
+  let project_path = PathBuf::from(project_dir);
+  // Auth via the global CLI: the migrate flow only writes report/model files into
+  // the project via `fs`, and the freshly-created project's deps aren't installed.
+  // `project_auth_module` never installs, so this can't hang on `npm install`.
+  let auth_path = match project_auth_module(None).await {
+    Ok(p) => p,
+    Err(error) => return fail(None, error),
+  };
+
+  let script_path = match write_helper("fabric-report-definition.mjs", DEFINITION_HELPER_SOURCE) {
+    Ok(p) => p,
+    Err(err) => return fail(None, format!("Could not prepare the definition helper: {err}")),
+  };
+
+  let dest_dir = project_path.join(sub_dir);
+  let auth_str = auth_path.to_string_lossy().to_string();
+  let script_str = script_path.to_string_lossy().to_string();
+  let dest_str = dest_dir.to_string_lossy().to_string();
+  let res = exec::run(
+    "node",
+    &[
+      &script_str,
+      &auth_str,
+      FABRIC_API_BASE,
+      mode,
+      workspace_id,
+      item_id,
+      &dest_str,
+    ],
+    RunOptions::timeout(300_000),
+  )
+  .await;
+
+  if res.not_found {
+    return fail(None, "Node.js was not found on PATH.".to_string());
+  }
+
+  let out = res.stdout.trim();
+  match serde_json::from_str::<FabricReportDefinitionResult>(out) {
+    Ok(parsed) => parsed,
+    Err(_) => {
+      let (needs_login, err) = failure_error(&res, out);
+      fail(Some(needs_login), err)
+    }
+  }
+}
+
+/// Export a Power BI report to a PDF (every page) via the Power BI `ExportTo`
+/// REST API and write it to `<projectDir>/source-report/report.pdf`, returning it
+/// base64-encoded so the renderer can rasterize each page into an image for the
+/// migrate chat hand-off. Best-effort in the migrate flow: image export is
+/// tenant-blocked on many tenants (so we export PDF), and PDF export needs a
+/// capacity-backed workspace — a failure here is surfaced but never blocks the
+/// migration. Runs through the *global* Rayfin CLI so it never waits on the new
+/// project's install; may pop a one-time Power BI consent window.
+#[tauri::command]
+pub async fn fabric_export_report_pdf(
+  workspace_id: String,
+  report_id: String,
+  project_dir: String,
+) -> FabricExportPdfResult {
+  let fail = |needs_login: Option<bool>, error: String| FabricExportPdfResult {
+    ok: false,
+    pdf_path: None,
+    pdf_base64: None,
+    bytes: None,
+    needs_login,
+    error: Some(error),
+  };
+
+  let project_path = PathBuf::from(&project_dir);
+  let auth_path = match project_auth_module(None).await {
+    Ok(p) => p,
+    Err(error) => return fail(None, error),
+  };
+
+  let script_path = match write_helper("fabric-export-pdf.mjs", EXPORT_PDF_HELPER_SOURCE) {
+    Ok(p) => p,
+    Err(err) => return fail(None, format!("Could not prepare the export helper: {err}")),
+  };
+
+  let dest = project_path.join("source-report").join("report.pdf");
+  let auth_str = auth_path.to_string_lossy().to_string();
+  let script_str = script_path.to_string_lossy().to_string();
+  let dest_str = dest.to_string_lossy().to_string();
+  let res = exec::run(
+    "node",
+    &[
+      &script_str,
+      &auth_str,
+      FABRIC_PBI_BASE,
+      &workspace_id,
+      &report_id,
+      &dest_str,
+    ],
+    RunOptions::timeout(300_000),
+  )
+  .await;
+
+  if res.not_found {
+    return fail(None, "Node.js was not found on PATH.".to_string());
+  }
+
+  let out = res.stdout.trim();
+  match serde_json::from_str::<FabricExportPdfResult>(out) {
+    Ok(parsed) => parsed,
+    Err(_) => {
+      let (needs_login, err) = failure_error(&res, out);
+      fail(Some(needs_login), err)
+    }
+  }
+}
+
+/// Node helper that opens the interactive Fabric sign-in / consent window so the
+/// migrate flow can reach a signed-in session from the Home screen (where no
+/// project is active and the CLI has no cached account). argv: <authModulePath>.
+const SIGNIN_HELPER_SOURCE: &str = r#"// Keep stdout clean for the JSON result; route any library logging to stderr.
+console.log = (...a) => process.stderr.write(a.map(String).join(' ') + '\n')
+console.debug = console.log
+console.info = console.log
+
+import { pathToFileURL } from 'node:url'
+
+async function main() {
+  const [authPath] = process.argv.slice(2)
+  const auth = await import(pathToFileURL(authPath).href)
+  const rf = await auth.getRayfinAuth()
+  // Omit silentOnly so acquireToken falls back to an interactive browser login
+  // when there's no cached account. Undefined scopes → the CLI's default Fabric
+  // scope (read); the write scope is requested later, only when a report is
+  // actually migrated.
+  await rf.acquireToken(undefined, { silentOnly: false })
+  process.stdout.write(JSON.stringify({ ok: true }))
+}
+
+main().catch((err) => {
+  const msg = err && err.message ? String(err.message) : String(err)
+  process.stdout.write(JSON.stringify({ ok: false, error: msg }))
+})
+"#;
+
+/// Open the interactive Fabric sign-in window (silent when already signed in) so
+/// the migrate-report flow can list workspaces from the Home screen. Uses the
+/// active project's CLI when one is open, else the global `rayfin` install.
+#[tauri::command]
+pub async fn fabric_sign_in() -> FabricSignInResult {
+  let candidates = account_auth_modules();
+  if candidates.is_empty() {
+    return FabricSignInResult {
+      ok: false,
+      error: Some(
+        "Could not locate the Rayfin CLI. Open a Rayfin project to reach Fabric.".to_string(),
+      ),
+    };
+  }
+
+  let script_path = match write_helper("fabric-sign-in.mjs", SIGNIN_HELPER_SOURCE) {
+    Ok(p) => p,
+    Err(err) => {
+      return FabricSignInResult {
+        ok: false,
+        error: Some(format!("Could not prepare the sign-in helper: {err}")),
+      }
+    }
+  };
+
+  let script_str = script_path.to_string_lossy().to_string();
+  let res = run_fabric_helper(&script_str, &[], 300_000, &candidates).await;
+
+  if res.not_found {
+    return FabricSignInResult {
+      ok: false,
+      error: Some("Node.js was not found on PATH.".to_string()),
+    };
+  }
+
+  let out = res.stdout.trim();
+  match serde_json::from_str::<FabricSignInResult>(out) {
+    Ok(parsed) => parsed,
+    Err(_) => {
+      let (_needs_login, err) = failure_error(&res, out);
+      FabricSignInResult {
+        ok: false,
         error: Some(err),
       }
     }
@@ -735,6 +1481,38 @@ mod tests {
     assert_eq!(ids, vec!["2", "3", "1"]);
   }
 
+  fn run_result(stdout: &str, stderr: &str) -> exec::RunResult {
+    exec::RunResult {
+      ok: false,
+      exit_code: Some(1),
+      stdout: stdout.to_string(),
+      stderr: stderr.to_string(),
+      not_found: false,
+    }
+  }
+
+  #[test]
+  fn module_load_failure_detected_on_stdout_and_stderr() {
+    // The helper catches the failed dynamic import() into its JSON on stdout…
+    let caught = run_result(
+      r#"{"ok":false,"needsLogin":false,"error":"Cannot find module 'C:\\proj\\node_modules\\@azure\\msal-node\\dist\\index.mjs' imported from rayfin-auth.js"}"#,
+      "",
+    );
+    assert!(is_module_load_failure(&caught));
+
+    // …or, when uncaught, node writes ERR_MODULE_NOT_FOUND to stderr.
+    let uncaught = run_result("", "node:internal/errors ... [ERR_MODULE_NOT_FOUND]: Cannot find package");
+    assert!(is_module_load_failure(&uncaught));
+  }
+
+  #[test]
+  fn real_auth_failure_is_not_a_module_load_failure() {
+    // A genuine "no cached account" must NOT be mistaken for a broken CLI, so we
+    // don't needlessly retry the global module (and hide a real login prompt).
+    let login = run_result(r#"{"ok":false,"needsLogin":true,"error":"no cached account"}"#, "");
+    assert!(!is_module_load_failure(&login));
+  }
+
   #[test]
   fn delete_result_shape_deserializes() {
     let ok: FabricDeleteResult =
@@ -784,5 +1562,32 @@ mod tests {
     // Create-workspace helper POSTs a workspace; capacities helper excludes PPU.
     assert!(CREATE_WS_HELPER_SOURCE.contains("method: 'POST'"));
     assert!(CAPACITIES_HELPER_SOURCE.contains("s.startsWith('PP')"));
+  }
+
+  #[test]
+  fn definition_helper_resolves_all_model_id_forms() {
+    // resolveModelId must cover every place the bound dataset GUID can appear,
+    // including the modern PBIR v4 `byConnection` connection string where the id
+    // is a `semanticmodelid=` param (and `initial catalog=` is the model *name*).
+    assert!(DEFINITION_HELPER_SOURCE.contains("function resolveModelId"));
+    assert!(DEFINITION_HELPER_SOURCE.contains("semanticmodelid"));
+    assert!(DEFINITION_HELPER_SOURCE.contains("pbiModelDatabaseName"));
+    assert!(DEFINITION_HELPER_SOURCE.contains("Initial Catalog="));
+    assert!(DEFINITION_HELPER_SOURCE.contains("datasetId"));
+  }
+
+  #[test]
+  fn export_pdf_helper_uses_powerbi_export_to_pdf() {
+    // The migrate "capture pages" sub-step exports a PDF (image export is
+    // tenant-blocked on many tenants) via the Power BI ExportTo API, polls the
+    // long-running op, and returns the file base64 for renderer rasterization.
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("getRayfinAuth"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("analysis.windows.net/powerbi/api/.default"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("/ExportTo"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("format: 'PDF'"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("Succeeded"));
+    assert!(EXPORT_PDF_HELPER_SOURCE.contains("pdfBase64"));
+    // Power BI-audience base, distinct from the Fabric API base.
+    assert_eq!(FABRIC_PBI_BASE, "https://api.powerbi.com/v1.0/myorg");
   }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -160,6 +160,7 @@ pub fn run() {
       commands::fabric::fabric_reports,
       commands::fabric::fabric_report_definition,
       commands::fabric::fabric_export_report_pdf,
+      commands::fabric::fabric_save_report_pages,
       commands::fabric::fabric_semantic_model_definition,
       commands::fabric::fabric_sign_in,
       commands::fabric::fabric_capacities,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -157,6 +157,11 @@ pub fn run() {
       commands::github::github_clone,
       // fabric
       commands::fabric::fabric_workspaces,
+      commands::fabric::fabric_reports,
+      commands::fabric::fabric_report_definition,
+      commands::fabric::fabric_export_report_pdf,
+      commands::fabric::fabric_semantic_model_definition,
+      commands::fabric::fabric_sign_in,
       commands::fabric::fabric_capacities,
       commands::fabric::fabric_create_workspace,
       commands::fabric::fabric_delete_apps,

--- a/src-tauri/src/services/agent_skills.rs
+++ b/src-tauri/src/services/agent_skills.rs
@@ -221,6 +221,126 @@ straight into a data connection. Once you have a model's `workspaceId` and `item
   validate-headless skill); Fabricator auto-deploys the app after the turn.
 "#;
 
+/// Always-on instruction: Fabricator owns dependency installation, so the agent
+/// must never run its own `npm install` (a second install in the same project
+/// races the app's background install and corrupts `node_modules`).
+const MANAGED_DEPS_INSTRUCTIONS: &str = r#"---
+applyTo: '**'
+---
+# Dependencies are installed and managed by Fabricator
+
+You are the coding agent inside **Fabricator**. Fabricator installs and manages this
+project's npm dependencies for you — it runs the install when the project opens and
+shows the user an install-status banner (with a **Retry**) if it fails. Managing
+`node_modules` yourself starts a second install in the same folder, which races the
+app's install and corrupts it.
+
+## Never install or mutate dependencies
+Do **not** run any of these (or their equivalents):
+
+- `npm install` / `npm i` / `npm ci` / `npm update` / `npm rebuild`
+- `pnpm install` / `yarn` / `yarn install` / `bun install`
+- Deleting, moving, or hand-editing `node_modules/`, `package-lock.json`, or any lockfile.
+
+Editing `package.json` to add a dependency is fine when a task genuinely needs a new
+package — but do **not** then run an install; tell the user which package you added
+and let Fabricator install it.
+
+(`npx fabric-app-data …` is **not** a dependency install — it's the app's own data
+CLI. Keep using it, and the build/preview scripts, normally.)
+
+## If a command fails because a module is missing
+That means the background install hasn't finished yet (or failed) — **not** that you
+should install it. Instead:
+
+1. Wait a few seconds and retry the **same** command once or twice; the install
+   usually finishes within a minute of the project opening.
+2. If it still fails, stop and tell the user their dependencies are still installing
+   or failed to install, and point them at the install banner's **Retry installation**
+   button. Do not try to work around it by installing packages yourself.
+"#;
+
+/// Model-invoked skill for rebuilding an imported Power BI report (PBIR / legacy
+/// report.json + semantic-model TMDL under `source-report/` and `source-model/`)
+/// as this data app: read the report as the UI spec, find the semantic model id it
+/// binds to, wire a live connection, reuse its DAX, and map visuals to Graphein.
+const BUILD_FROM_REPORT_SKILL: &str = r#"---
+name: build-from-powerbi-report
+description: "Rebuild an imported Power BI report as this Rayfin data app. Use whenever the project contains an imported report under `source-report/` (a PBIR `definition.pbir` / `definition/` folder, or a classic `report.json`) and/or a semantic model under `source-model/` (TMDL) — e.g. a migrated Power BI report. Covers reading the report as the UI spec, finding the semantic model id it binds to, wiring a live connection, reusing its DAX, and mapping its visuals to Graphein specs."
+metadata:
+  author: Fabricator
+  version: 1.0.0
+---
+# Rebuild an imported Power BI report
+
+You are running inside **Fabricator**, rebuilding an existing Power BI report as a
+Rayfin **data app** that reads from the report's own Fabric **semantic model**, live.
+The importer dropped two reference folders in the project:
+
+- **`source-report/`** — the report definition: a PBIR `definition.pbir` + `definition/`
+  folder (pages, visuals, layout), or a classic `report.json` for a legacy report. This
+  is the **UI spec** — what pages, visuals, and layout to rebuild.
+- **`source-model/`** — the semantic model as **TMDL** (tables, relationships,
+  measures/DAX). This is **schema + DAX reference — metadata, not data.**
+
+Both are references you read; they are not wired into the app. Your job: connect to the
+live model and rebuild the visuals with Graphein.
+
+## 1. Find the semantic model it binds to
+Fabricator usually hands you the model's coordinates (workspace id + dataset id) in the
+message that opens this chat — **use those directly** when present. If you need to find
+the id yourself, read the report's PBIR and look for the dataset reference:
+
+- Open `source-report/definition.pbir` (or files under `source-report/definition/`).
+- Modern PBIR (`version` 4.0+) stores the binding as a **connection string** under
+  `datasetReference.byConnection.connectionString`. The dataset GUID is the
+  **`semanticmodelid=<GUID>`** param — e.g. `…;semanticmodelid=<GUID>`. **Note the
+  `initial catalog=<name>` in that same string is the model's display name, NOT a
+  GUID — don't use it as the id.**
+- Older/thick PBIR instead exposes the GUID as a **`pbiModelDatabaseName`** under
+  `datasetReference.byConnection` — e.g. `"pbiModelDatabaseName": "<GUID>"`.
+- Either way, that GUID is the Power BI **dataset id, which IS the
+  Fabric semantic-model item id.** Further fallbacks: an `Initial Catalog=<GUID>`
+  in a connection string, or a `"datasetId": "<GUID>"`.
+- A **`byPath`** reference (a model inside the same PBIP project) has no remote id —
+  resolve it with **`fabricator_locate_semantic_model`** (pass the report/model link or
+  a GUID), or ask the user for the workspace + dataset id.
+
+## 2. Wire the model as a live connection
+Once you have `workspaceId` + `itemId` (= the dataset id), add it and generate — see the
+**fabric-data** and **connect-semantic-model** skills for the full surface:
+
+```
+fabric-app-data add <alias> -w <workspaceId> -i <itemId>
+```
+
+Then query it live with `useSemanticModelQuery` / `fabric-app-data query`. **Do not
+import, copy, or reload the data, and do not recreate the model as Rayfin `data`
+entities** — the data stays in the semantic model and the app reads it on demand. You
+can disable the `data` service in `rayfin/rayfin.yml`.
+
+## 3. Reuse the report's DAX
+The TMDL in `source-model/` holds the measure names and expressions the original report
+used. **Reuse the exact measure names** (and their definitions where you must recompute)
+so your numbers match the original report. Prefer the model's own measures over
+re-deriving aggregates in TypeScript. (→ `dax`)
+
+## 4. Rebuild the visuals as Graphein specs
+Treat `source-report/` as the layout brief, not something to port line-for-line:
+
+- Each report page → a dashboard page/section; each visual → the closest Graphein spec
+  (`ChartCard` / `KpiCard` / `DataTableCard`), authored from a DAX result. (→ `visuals`)
+- Report slicers → React slicers over shared filter state; cross-filtering → Graphein
+  selections. (→ `visuals`: Interactivity)
+- Start with ONE hero visual wired to live data, preview it, then expand. (→ `build-workflow`)
+
+## Notes
+- If the model can't be resolved or you lack access to it, say so and ask the user for
+  the workspace + dataset id — don't fall back to copying data out of the TMDL.
+- Validate every visual headlessly with `npm run preview`; Fabricator auto-deploys after
+  the turn. Don't run `rayfin up`, a dev server, or `npm install`.
+"#;
+
 /// Write (or refresh) the injected skill + instruction files under the app data
 /// dir. Idempotent and best-effort: always overwrites so content updates ship
 /// with the app. Call once at startup, before any session opens.
@@ -242,10 +362,15 @@ fn write_all(root: &std::path::Path) -> std::io::Result<()> {
   std::fs::create_dir_all(&connect_dir)?;
   std::fs::write(connect_dir.join("SKILL.md"), CONNECT_MODEL_SKILL)?;
 
+  let report_dir = root.join("skills").join("build-from-powerbi-report");
+  std::fs::create_dir_all(&report_dir)?;
+  std::fs::write(report_dir.join("SKILL.md"), BUILD_FROM_REPORT_SKILL)?;
+
   let instr_dir = root.join("instructions");
   std::fs::create_dir_all(&instr_dir)?;
   std::fs::write(instr_dir.join("fabricator-validate.instructions.md"), VALIDATE_INSTRUCTIONS)?;
   std::fs::write(instr_dir.join("fabricator-stable-only.instructions.md"), STABLE_ONLY_INSTRUCTIONS)?;
+  std::fs::write(instr_dir.join("fabricator-dependencies.instructions.md"), MANAGED_DEPS_INSTRUCTIONS)?;
   Ok(())
 }
 
@@ -338,6 +463,39 @@ mod tests {
   }
 
   #[test]
+  fn managed_deps_instructions_forbid_agent_install() {
+    assert!(MANAGED_DEPS_INSTRUCTIONS.contains("applyTo: '**'"));
+    // Fabricator owns the install; the agent must never start its own.
+    for forbidden in ["npm install", "npm ci", "yarn install", "pnpm install"] {
+      assert!(
+        MANAGED_DEPS_INSTRUCTIONS.contains(forbidden),
+        "managed-deps instructions should ban {forbidden}"
+      );
+    }
+    // ...but the app's own data CLI stays allowed, and missing modules mean "wait".
+    assert!(MANAGED_DEPS_INSTRUCTIONS.contains("fabric-app-data"));
+    assert!(MANAGED_DEPS_INSTRUCTIONS.contains("Retry installation"));
+  }
+
+  #[test]
+  fn build_from_report_skill_documents_model_id_and_wiring() {
+    assert!(BUILD_FROM_REPORT_SKILL.starts_with("---\n"));
+    assert!(BUILD_FROM_REPORT_SKILL.contains("name: build-from-powerbi-report"));
+    // Names the reference folders the importer drops in.
+    assert!(BUILD_FROM_REPORT_SKILL.contains("source-report/"));
+    assert!(BUILD_FROM_REPORT_SKILL.contains("source-model/"));
+    // Teaches where the semantic model id lives in the PBIR and the id-equivalence.
+    assert!(BUILD_FROM_REPORT_SKILL.contains("pbiModelDatabaseName"));
+    // ...including the modern PBIR v4 connection-string form.
+    assert!(BUILD_FROM_REPORT_SKILL.contains("semanticmodelid"));
+    assert!(BUILD_FROM_REPORT_SKILL.contains("Fabric semantic-model item id"));
+    assert!(BUILD_FROM_REPORT_SKILL.contains("fabricator_locate_semantic_model"));
+    // ...and reuses the model live rather than copying the data out of the TMDL.
+    assert!(BUILD_FROM_REPORT_SKILL.contains("fabric-app-data add <alias> -w <workspaceId> -i <itemId>"));
+    assert!(BUILD_FROM_REPORT_SKILL.contains("do not recreate the model as Rayfin `data`"));
+  }
+
+  #[test]
   fn write_all_creates_expected_layout() {
     let tmp = std::env::temp_dir().join(format!("fab-agent-test-{}", std::process::id()));
     let _ = std::fs::remove_dir_all(&tmp);
@@ -345,15 +503,21 @@ mod tests {
 
     let skill = tmp.join("skills").join("validate-headless").join("SKILL.md");
     let connect = tmp.join("skills").join("connect-semantic-model").join("SKILL.md");
+    let report = tmp.join("skills").join("build-from-powerbi-report").join("SKILL.md");
     let instr = tmp.join("instructions").join("fabricator-validate.instructions.md");
     let stable = tmp.join("instructions").join("fabricator-stable-only.instructions.md");
+    let deps = tmp.join("instructions").join("fabricator-dependencies.instructions.md");
     assert!(skill.is_file(), "SKILL.md should exist at {skill:?}");
     assert!(connect.is_file(), "connect SKILL.md should exist at {connect:?}");
+    assert!(report.is_file(), "build-from-report SKILL.md should exist at {report:?}");
     assert!(instr.is_file(), "instructions file should exist at {instr:?}");
     assert!(stable.is_file(), "stable-only instructions should exist at {stable:?}");
+    assert!(deps.is_file(), "managed-deps instructions should exist at {deps:?}");
     assert_eq!(std::fs::read_to_string(&skill).unwrap(), VALIDATE_HEADLESS_SKILL);
     assert_eq!(std::fs::read_to_string(&connect).unwrap(), CONNECT_MODEL_SKILL);
+    assert_eq!(std::fs::read_to_string(&report).unwrap(), BUILD_FROM_REPORT_SKILL);
     assert_eq!(std::fs::read_to_string(&stable).unwrap(), STABLE_ONLY_INSTRUCTIONS);
+    assert_eq!(std::fs::read_to_string(&deps).unwrap(), MANAGED_DEPS_INSTRUCTIONS);
 
     let _ = std::fs::remove_dir_all(&tmp);
   }

--- a/src-tauri/src/types.rs
+++ b/src-tauri/src/types.rs
@@ -147,6 +147,89 @@ pub struct FabricWorkspacesResult {
   pub error: Option<String>,
 }
 
+/// A Power BI report living in a Fabric workspace (candidate for migration).
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FabricReport {
+  pub id: String,
+  pub display_name: String,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub description: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub web_url: Option<String>,
+}
+
+/// Outcome of listing a workspace's Power BI reports (never throws across IPC).
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FabricReportsResult {
+  pub ok: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub reports: Option<Vec<FabricReport>>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub needs_login: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<String>,
+}
+
+/// Outcome of downloading a report's public definition (PBIR files written to
+/// disk). Never throws across IPC — reports `needsLogin`/`error` for the UI.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FabricReportDefinitionResult {
+  pub ok: bool,
+  /// Relative paths (under the destination dir) of the files written.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub files: Option<Vec<String>>,
+  /// Absolute directory the report files were written into.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub dir: Option<String>,
+  /// The report's bound semantic model id, resolved from its `definition.pbir`
+  /// (report mode only). The migrate flow uses it to download the model next.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub model_id: Option<String>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub needs_login: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<String>,
+}
+
+/// Outcome of a Power BI report → PDF export (the migrate flow's "capture report
+/// pages" sub-step). The PDF is returned inline (base64) so the renderer can
+/// rasterize each page to an image with pdf.js and stage them as chat
+/// attachments; a copy is also written to `source-report/report.pdf`. Best-effort
+/// in the UI — a failure (e.g. image/PDF export disabled on the tenant, or a
+/// non-capacity workspace) is surfaced but never blocks the migration.
+/// Never throws across IPC — reports `needsLogin`/`error` for the UI.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FabricExportPdfResult {
+  pub ok: bool,
+  /// Absolute path the exported PDF was written to (`source-report/report.pdf`).
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub pdf_path: Option<String>,
+  /// The exported PDF, base64-encoded, for the renderer to rasterize.
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub pdf_base64: Option<String>,
+  /// Byte length of the exported PDF (diagnostics / progress copy).
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub bytes: Option<u64>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub needs_login: Option<bool>,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<String>,
+}
+
+/// Outcome of the interactive Fabric sign-in used by the migrate-report flow.
+/// Never throws across IPC — reports `error` for the UI.
+#[derive(Serialize, Deserialize, Clone)]
+#[serde(rename_all = "camelCase")]
+pub struct FabricSignInResult {
+  pub ok: bool,
+  #[serde(skip_serializing_if = "Option::is_none")]
+  pub error: Option<String>,
+}
+
 /// A dedicated capacity the signed-in user can create a workspace on.
 #[derive(Serialize, Deserialize, Clone)]
 #[serde(rename_all = "camelCase")]

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -91,6 +91,14 @@ export const api: RayfinStudioApi = {
 
   fabric: {
     listWorkspaces: () => invoke('fabric_workspaces'),
+    listReports: (workspaceId: string) => invoke('fabric_reports', { workspaceId }),
+    reportDefinition: (workspaceId: string, reportId: string, projectDir: string) =>
+      invoke('fabric_report_definition', { workspaceId, reportId, projectDir }),
+    semanticModelDefinition: (workspaceId: string, modelId: string, projectDir: string) =>
+      invoke('fabric_semantic_model_definition', { workspaceId, modelId, projectDir }),
+    exportReportPdf: (workspaceId: string, reportId: string, projectDir: string) =>
+      invoke('fabric_export_report_pdf', { workspaceId, reportId, projectDir }),
+    signIn: () => invoke('fabric_sign_in', {}),
     listCapacities: () => invoke('fabric_capacities'),
     createWorkspace: (name: string, capacityId: string) =>
       invoke('fabric_create_workspace', { name, capacityId }),

--- a/src/renderer/src/api.ts
+++ b/src/renderer/src/api.ts
@@ -98,6 +98,8 @@ export const api: RayfinStudioApi = {
       invoke('fabric_semantic_model_definition', { workspaceId, modelId, projectDir }),
     exportReportPdf: (workspaceId: string, reportId: string, projectDir: string) =>
       invoke('fabric_export_report_pdf', { workspaceId, reportId, projectDir }),
+    saveReportPages: (projectDir: string, pages: string[]) =>
+      invoke('fabric_save_report_pages', { projectDir, pages }),
     signIn: () => invoke('fabric_sign_in', {}),
     listCapacities: () => invoke('fabric_capacities'),
     createWorkspace: (name: string, capacityId: string) =>

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -2624,6 +2624,72 @@ code {
   white-space: pre-wrap;
   word-break: break-word;
 }
+.ws-signin {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 8px;
+}
+.migrate-fetch {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  margin-top: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--surface);
+}
+.migrate-fetch--running {
+  background: color-mix(in srgb, var(--accent) 10%, transparent);
+  border-color: color-mix(in srgb, var(--accent) 35%, var(--border));
+}
+.migrate-fetch--error {
+  border-color: color-mix(in srgb, var(--danger) 45%, var(--border));
+}
+.migrate-fetch--pending {
+  opacity: 0.55;
+}
+.migrate-fetch-ico {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  margin-top: 1px;
+  flex: 0 0 18px;
+  font-size: 14px;
+  font-weight: 700;
+}
+.migrate-fetch--done .migrate-fetch-ico {
+  color: var(--ok);
+}
+.migrate-fetch--skipped .migrate-fetch-ico,
+.migrate-fetch--pending .migrate-fetch-ico {
+  color: var(--text-dim);
+}
+.migrate-fetch--error .migrate-fetch-ico {
+  color: var(--danger);
+}
+.migrate-fetch-body {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.migrate-fetch-label {
+  font-size: 13px;
+  line-height: 1.4;
+  color: var(--text);
+}
+.migrate-fetch-detail {
+  font-size: 11.5px;
+  line-height: 1.45;
+  color: var(--text-dim);
+}
+.migrate-fetch--error .migrate-fetch-detail {
+  color: var(--danger);
+}
 .ws-empty-actions {
   display: flex;
   gap: 8px;
@@ -6951,7 +7017,7 @@ code {
 
 .home-actions {
   display: grid;
-  grid-template-columns: minmax(0, 1.15fr) repeat(2, minmax(0, 1fr));
+  grid-template-columns: minmax(0, 1.15fr) repeat(3, minmax(0, 1fr));
   gap: 10px;
   margin-top: 4px;
 }

--- a/src/renderer/src/components/ChatPanel.test.tsx
+++ b/src/renderer/src/components/ChatPanel.test.tsx
@@ -564,6 +564,123 @@ describe('ChatPanel onTurnStart (live local preview hook)', () => {
 })
 
 /**
+ * Outbound autoSend (the migrate hand-off): a prompt flagged `autoSend` submits
+ * itself once a new turn is allowed. The migrate flow seeds it while the first
+ * deploy is still streaming, so it must stay staged in the composer behind the
+ * deploy gate and fire the instant the gate clears — never require an Enter.
+ */
+describe('ChatPanel outbound autoSend', () => {
+  const sendMock = (): ReturnType<typeof vi.fn> =>
+    (window as unknown as { api: { chat: { send: ReturnType<typeof vi.fn> } } }).api.chat.send
+
+  it('stages an autoSend prompt behind the deploy gate, then fires it when the gate clears', async () => {
+    const onConsumed = vi.fn()
+    const outbound = {
+      id: 'mig-1',
+      display: 'Migrate report',
+      prompt: 'rebuild this report',
+      autoSend: true
+    }
+    let rerender: ReturnType<typeof render>['rerender'] = () => {}
+    await act(async () => {
+      const r = render(
+        <ChatPanel
+          project={makeProject('p1')}
+          messages={[]}
+          onChange={() => {}}
+          draft=""
+          deployLock
+          outbound={outbound}
+          onOutboundConsumed={onConsumed}
+        />
+      )
+      rerender = r.rerender
+    })
+
+    // Gate up: staged in the composer, not sent.
+    const ta = screen.getByRole('textbox') as HTMLTextAreaElement
+    expect(ta.value).toBe('rebuild this report')
+    expect(sendMock()).not.toHaveBeenCalled()
+    expect(onConsumed).toHaveBeenCalledTimes(1)
+
+    // Deploy lands → gate clears → the prompt submits itself, composer cleared.
+    await act(async () => {
+      rerender(
+        <ChatPanel
+          project={makeProject('p1')}
+          messages={[]}
+          onChange={() => {}}
+          draft=""
+          deployLock={false}
+          outbound={outbound}
+          onOutboundConsumed={onConsumed}
+        />
+      )
+    })
+    await waitFor(() => expect(sendMock()).toHaveBeenCalled())
+    const calls = sendMock().mock.calls
+    const [, , prompt] = calls[calls.length - 1] ?? []
+    expect(prompt).toBe('rebuild this report')
+    expect((screen.getByRole('textbox') as HTMLTextAreaElement).value).toBe('')
+  })
+
+  it('sends an autoSend prompt immediately when no gate is up, showing the full prompt as the message', async () => {
+    // Capture the visible user message the panel appends so we can assert the
+    // bubble shows the full prompt (not a short display label).
+    const userTexts: string[] = []
+    const onChange = (updater: (prev: UIChatMessage[]) => UIChatMessage[]): void => {
+      for (const m of updater([])) if (m.role === 'user') userTexts.push(m.text)
+    }
+    await act(async () => {
+      render(
+        <ChatPanel
+          project={makeProject('p1')}
+          messages={[]}
+          onChange={onChange}
+          draft=""
+          outbound={{ id: 'mig-2', display: 'Migrate report', prompt: 'rebuild it now', autoSend: true }}
+        />
+      )
+    })
+    await waitFor(() => expect(sendMock()).toHaveBeenCalled())
+    const calls = sendMock().mock.calls
+    const [, , prompt] = calls[calls.length - 1] ?? []
+    expect(prompt).toBe('rebuild it now')
+    // The visible message is the full prompt, not the short display label.
+    expect(userTexts.at(-1)).toBe('rebuild it now')
+    expect(userTexts).not.toContain('Migrate report')
+  })
+
+  it('forwards autoSend attachment paths to chat.send (the migrate report-page images)', async () => {
+    await act(async () => {
+      render(
+        <ChatPanel
+          project={makeProject('p1')}
+          messages={[]}
+          onChange={() => {}}
+          draft=""
+          outbound={{
+            id: 'mig-3',
+            display: 'Migrate report',
+            prompt: 'rebuild it now',
+            autoSend: true,
+            attachments: [
+              { path: '/tmp/page-1.png', thumb: 'data:image/png;base64,AAAA' },
+              { path: '/tmp/page-2.png', thumb: 'data:image/png;base64,BBBB' }
+            ]
+          }}
+        />
+      )
+    })
+    await waitFor(() => expect(sendMock()).toHaveBeenCalled())
+    const calls = sendMock().mock.calls
+    // chat.send(projectId, turnId, prompt, attachmentPaths[], mode)
+    const [, , , attachments] = calls[calls.length - 1] ?? []
+    expect(attachments).toEqual(['/tmp/page-1.png', '/tmp/page-2.png'])
+  })
+})
+
+/**
  * Live local preview lifecycle: submitting a new turn while a deploy is in flight
  * used to leave the local preview unable to start (and never come back). With the
  * experiment on, submitting is paused during a deploy — typing stays enabled — so

--- a/src/renderer/src/components/ChatPanel.tsx
+++ b/src/renderer/src/components/ChatPanel.tsx
@@ -83,6 +83,19 @@ export interface OutboundPrompt {
    * so the user can append their actual request before sending.
    */
   stage?: boolean
+  /**
+   * When true the prompt submits itself automatically as soon as a new turn is
+   * allowed. If the deploy gate is still up (a migrate seeds chat while its
+   * first deploy is streaming), it's staged in the composer and fired the moment
+   * the gate clears. Takes precedence over {@link stage}.
+   */
+  autoSend?: boolean
+  /**
+   * Image attachments to send with the prompt (e.g. the migrate flow's rendered
+   * report-page PNGs). Threaded through to `chat.send` as `--attachment` paths
+   * and shown as thumbnails on the user bubble.
+   */
+  attachments?: PendingShot[]
 }
 
 interface Props {
@@ -2432,17 +2445,42 @@ export default function ChatPanel({
   // notify the parent so it clears the one-shot prompt; otherwise it would
   // replay every time this panel remounts (e.g. after switching tabs).
   const handledOutbound = useRef<string | null>(null)
+  // A prompt flagged autoSend fires itself once a new turn is allowed. If the
+  // deploy gate is still up (the migrate flow seeds chat while the first deploy
+  // is streaming), we stash it here and flush it the moment the gate clears.
+  const autoSendPrompt = useRef<{ prompt: string; shots: PendingShot[] } | null>(null)
   useEffect(() => {
     if (!outbound || outbound.id === handledOutbound.current) return
     handledOutbound.current = outbound.id
-    if (sending || outbound.stage) {
+    const shots = outbound.attachments ?? []
+    if (outbound.autoSend) {
+      // Fire now if nothing blocks a turn; otherwise stage it in the composer
+      // and let the flush effect send it. Send the full prompt as the visible
+      // message so the user sees exactly what was submitted, not a short label.
+      if (!sending && !deployLock && !submitBlocked) {
+        void dispatch(outbound.prompt, outbound.prompt, shots)
+      } else {
+        setInput(outbound.prompt)
+        autoSendPrompt.current = { prompt: outbound.prompt, shots }
+      }
+    } else if (sending || outbound.stage) {
       setInput(outbound.prompt)
       taRef.current?.focus()
     } else {
-      void dispatch(outbound.display, outbound.prompt, [])
+      void dispatch(outbound.display, outbound.prompt, shots)
     }
     onOutboundConsumed?.()
   }, [outbound?.id])
+
+  // Flush a staged autoSend prompt once nothing blocks a new turn (deploy gate
+  // cleared, no deploy streaming, not mid-turn), clearing the composer as it fires.
+  useEffect(() => {
+    const pending = autoSendPrompt.current
+    if (!pending || sending || deployLock || submitBlocked) return
+    autoSendPrompt.current = null
+    setInput('')
+    void dispatch(pending.prompt, pending.prompt, pending.shots)
+  }, [sending, deployLock, submitBlocked])
 
   // Precompute the conversation rows so a keystroke in the composer (which only
   // touches local `input` state) doesn't re-run `messages.map` and re-create N

--- a/src/renderer/src/components/CreateProgress.tsx
+++ b/src/renderer/src/components/CreateProgress.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useRef, useState } from 'react'
+
+/** The coarse stages a scaffold goes through, in order. `done` is authoritative. */
+type CreatePhase = 'preparing' | 'customizing' | 'installing' | 'finalizing' | 'done'
+
+interface PhaseDef {
+  id: CreatePhase
+  label: string
+  hint?: string
+  /**
+   * Loose, lowercase fragments that signal this stage has begun. Kept broad and
+   * forgiving on purpose — see {@link markerPhase}.
+   */
+  markers: string[]
+}
+
+/**
+ * The visible create stages. `finalizing` keys off our *own* backend `say()`
+ * line ("Initializing git repository…"), which we control; `customizing` /
+ * `installing` key off the upstream `npm create @microsoft/rayfin` scaffolder.
+ * `done` is never marker-derived (see below).
+ */
+const CREATE_PHASES: PhaseDef[] = [
+  { id: 'preparing', label: 'Preparing', markers: [] },
+  { id: 'customizing', label: 'Customizing template', markers: ['customiz'] },
+  {
+    id: 'installing',
+    label: 'Installing dependencies',
+    hint: 'First run can take a minute or two.',
+    markers: ['install']
+  },
+  { id: 'finalizing', label: 'Finishing up', markers: ['initializing git', 'git repository'] }
+]
+
+const PHASE_ORDER: CreatePhase[] = ['preparing', 'customizing', 'installing', 'finalizing', 'done']
+const phaseRank = (p: CreatePhase): number => PHASE_ORDER.indexOf(p)
+
+/**
+ * Best-effort, **purely cosmetic** mapping of the cumulative create log to the
+ * furthest stage reached. Hardened so upstream output changes can never break
+ * or stall the actual create:
+ *  - It never reports `done` — completion is driven solely by the backend
+ *    result, so reworded/removed "finished" lines can't strand the wizard.
+ *  - Markers are loose substrings; missing them only softens the indicator
+ *    (the spinner + elapsed timer + {@link fallbackPhase} still convey motion).
+ *  - Wrapped so a parsing slip degrades gracefully instead of throwing.
+ */
+function markerPhase(log: string): CreatePhase {
+  try {
+    const l = log.toLowerCase()
+    let reached: CreatePhase = 'preparing'
+    for (const def of CREATE_PHASES) {
+      if (def.markers.length && def.markers.some((m) => l.includes(m))) reached = def.id
+    }
+    return reached
+  } catch {
+    return 'preparing'
+  }
+}
+
+/**
+ * Time-based floor so the indicator keeps advancing even if every upstream
+ * output marker changes. Capped at `installing` (the dominant time sink) — it
+ * never fabricates `finalizing`/`done`, which require a real signal/result.
+ */
+function fallbackPhase(elapsedSec: number, running: boolean): CreatePhase {
+  if (!running) return 'preparing'
+  if (elapsedSec >= 10) return 'installing'
+  if (elapsedSec >= 3) return 'customizing'
+  return 'preparing'
+}
+
+interface Props {
+  /** True while a create/scaffold IPC is streaming for this run. */
+  running: boolean
+  /** True once the backend result confirms success (authoritative). */
+  done: boolean
+  /** True once the run has ended in failure (reveals the raw log). */
+  failed: boolean
+}
+
+/**
+ * The shared "Preparing → Customizing → Installing → Finishing up" progress card
+ * for a project scaffold. Self-contained: it subscribes to the `create:project`
+ * proc-log channel, ticks its own elapsed clock, and derives the cosmetic phase.
+ * Completion is always driven by the `done`/`failed` props (never by log markers)
+ * so upstream output changes can't strand it. Renders nothing until a run starts.
+ */
+export default function CreateProgress({ running, done, failed }: Props): JSX.Element | null {
+  const [log, setLog] = useState('')
+  const [showDetails, setShowDetails] = useState(false)
+  const [startedAt, setStartedAt] = useState<number | null>(null)
+  const [now, setNow] = useState(0)
+  const logRef = useRef<HTMLPreElement>(null)
+  const wasRunning = useRef(false)
+
+  // Accumulate the scaffolder's streamed output for the details pane.
+  useEffect(() => {
+    const off = window.api.onProcLog((e) => {
+      if (e.channel === 'create:project') setLog((prev) => prev + e.data)
+    })
+    return off
+  }, [])
+
+  // Reset per run the moment a fresh create begins (false → true).
+  useEffect(() => {
+    if (running && !wasRunning.current) {
+      setLog('')
+      setShowDetails(false)
+      setStartedAt(Date.now())
+      setNow(Date.now())
+    }
+    wasRunning.current = running
+  }, [running])
+
+  // Surface the raw output the instant a run fails, so the real error is visible.
+  useEffect(() => {
+    if (failed) setShowDetails(true)
+  }, [failed])
+
+  // Tick a 1s elapsed clock while a create is in flight. This is the strongest
+  // "still working" cue during the output-silent npm install — and it's
+  // independent of any scaffolder/CLI log wording, so it survives upstream
+  // output changes.
+  useEffect(() => {
+    if (!running || startedAt == null) return
+    const id = window.setInterval(() => setNow(Date.now()), 1000)
+    return () => window.clearInterval(id)
+  }, [running, startedAt])
+
+  useEffect(() => {
+    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
+  }, [log, showDetails])
+
+  const elapsedSec = startedAt ? Math.max(0, Math.floor((now - startedAt) / 1000)) : 0
+  const elapsedLabel = `${Math.floor(elapsedSec / 60)}:${String(elapsedSec % 60).padStart(2, '0')}`
+  const detectedPhase = markerPhase(log)
+  const fallback = fallbackPhase(elapsedSec, running)
+  // Never regress: take the furthest of the parsed marker and the time floor.
+  const phase: CreatePhase = done
+    ? 'done'
+    : phaseRank(detectedPhase) >= phaseRank(fallback)
+      ? detectedPhase
+      : fallback
+  const activeIdx =
+    phase === 'done' ? CREATE_PHASES.length : CREATE_PHASES.findIndex((p) => p.id === phase)
+  const activePhaseLabel =
+    phase === 'done' ? 'Project ready' : (CREATE_PHASES[activeIdx]?.label ?? 'Preparing')
+
+  // Nothing to show until a run has started (or has already produced output).
+  if (!running && !done && !failed && !log) return null
+
+  return (
+    <div className="create-progress" aria-busy={running}>
+      <span className="sr-only" role="status" aria-live="polite">
+        {running ? activePhaseLabel : done ? 'Project ready' : ''}
+      </span>
+      <ol className="create-phases">
+        {CREATE_PHASES.map((p, i) => {
+          const state =
+            phase === 'done' || i < activeIdx ? 'done' : i === activeIdx ? 'active' : 'pending'
+          return (
+            <li
+              key={p.id}
+              className={`create-phase create-phase--${state}${
+                failed && state === 'active' ? ' create-phase--failed' : ''
+              }`}
+            >
+              <span className="create-phase-ico" aria-hidden="true">
+                {state === 'active' ? (
+                  running ? (
+                    <span className="ws-spinner" />
+                  ) : failed ? (
+                    '✕'
+                  ) : null
+                ) : state === 'done' ? (
+                  '✓'
+                ) : null}
+              </span>
+              <span className="create-phase-text">
+                <span className="create-phase-label">{p.label}</span>
+                {p.id === 'installing' && state === 'active' && (
+                  <span className="create-phase-hint">
+                    {elapsedSec > 75
+                      ? 'Still working — large dependency trees take a little longer.'
+                      : p.hint}
+                  </span>
+                )}
+              </span>
+            </li>
+          )
+        })}
+      </ol>
+
+      <div className="create-progress-meta">
+        <span className="create-elapsed" aria-hidden="true">
+          {running ? `${elapsedLabel} elapsed` : done ? 'Done' : ''}
+        </span>
+        <button
+          type="button"
+          className="link-btn create-progress-toggle"
+          onClick={() => setShowDetails((v) => !v)}
+        >
+          {showDetails ? 'Hide details' : 'Show details'}
+        </button>
+      </div>
+
+      {showDetails && (
+        <pre className="log-console log-console--sm create-progress-details" ref={logRef}>
+          {log || 'Starting…'}
+        </pre>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/CreateProjectScreen.tsx
+++ b/src/renderer/src/components/CreateProjectScreen.tsx
@@ -3,13 +3,54 @@ import type {
   CommunityGallery,
   FabricWorkspacesResult,
   ProjectActionResult,
+  StudioProject,
   TemplateInfo
 } from '@shared/ipc'
 import { useSuppressPreview } from '../overlay'
 import DeploymentCreateForm from './DeploymentCreateForm'
+import CreateProgress from './CreateProgress'
 
 type Mode = 'create' | 'deploy'
-type Step = 'details' | 'deploy'
+type Step = 'details' | 'migrate' | 'deploy'
+
+/**
+ * Configuration that turns the create flow into a Power BI migration. When set,
+ * the wizard runs three steps — Details (name your app, defaulted to the report
+ * name, then the *standard* create + install using the data-app template), Migrate
+ * (download the report's code + semantic model into the new project), then the
+ * standard Deploy step. Injected so migrate reuses the exact same `projects.create`
+ * + deploy path as a normal create.
+ */
+export interface MigrateSetup {
+  /** Human name for the created project (the report's display name). */
+  projectName: string
+  /**
+   * Download the report definition + semantic model into the freshly-created
+   * project. Runs after create, before Deploy. Progress is reported per sub-step
+   * via `onProgress`: `'code'` covers the PBIR + semantic-model download, and
+   * `'pages'` covers exporting the report to PDF and rasterizing each page into a
+   * chat attachment. A `status` marks a sub-step terminal (`'done'` / `'error'` /
+   * `'skipped'`); omitting it means the sub-step is still `'running'`. Returns an
+   * error string to abort (the screen rolls back the project), or null on success.
+   */
+  onFetchReportCode: (
+    project: StudioProject,
+    onProgress: (phase: MigratePhase, detail: string, status?: MigrateSubStatus) => void
+  ) => Promise<string | null>
+  /** Delete the just-created project (rollback) if fetch fails or the user cancels. */
+  onRollback: (project: StudioProject) => Promise<void>
+}
+
+/** The two sub-steps of the migrate fetch, reported independently to the UI. */
+export type MigratePhase = 'code' | 'pages'
+/** Terminal state of a migrate sub-step (absence ⇒ still running). */
+export type MigrateSubStatus = 'done' | 'error' | 'skipped'
+
+/** UI state for one migrate sub-step row: its current detail + lifecycle state. */
+interface MigrateSub {
+  detail: string
+  status: 'pending' | 'running' | MigrateSubStatus
+}
 
 interface Props {
   /** 'create' runs Details → Deploy; 'deploy' shows only the Deploy step for the active project. */
@@ -28,86 +69,23 @@ interface Props {
   deploying?: boolean
   /** Notify the parent that a Fabric sign-in just succeeded (refresh app auth). */
   onSignedIn?: () => void
+  /** When set, runs the create flow as a Power BI report migration (see {@link MigrateSetup}). */
+  migrate?: MigrateSetup
 }
 
 const keyOf = (t: { path?: string; name: string }): string => t.path || t.name
 
-/** The coarse stages a scaffold goes through, in order. `done` is authoritative. */
-type CreatePhase = 'preparing' | 'customizing' | 'installing' | 'finalizing' | 'done'
-
-interface PhaseDef {
-  id: CreatePhase
-  label: string
-  hint?: string
-  /**
-   * Loose, lowercase fragments that signal this stage has begun. Kept broad and
-   * forgiving on purpose — see {@link markerPhase}.
-   */
-  markers: string[]
-}
-
-/**
- * The visible create stages. `finalizing` keys off our *own* backend `say()`
- * line ("Initializing git repository…"), which we control; `customizing` /
- * `installing` key off the upstream `npm create @microsoft/rayfin` scaffolder.
- * `done` is never marker-derived (see below).
- */
-const CREATE_PHASES: PhaseDef[] = [
-  { id: 'preparing', label: 'Preparing', markers: [] },
-  { id: 'customizing', label: 'Customizing template', markers: ['customiz'] },
-  {
-    id: 'installing',
-    label: 'Installing dependencies',
-    hint: 'First run can take a minute or two.',
-    markers: ['install']
-  },
-  { id: 'finalizing', label: 'Finishing up', markers: ['initializing git', 'git repository'] }
-]
-
-const PHASE_ORDER: CreatePhase[] = ['preparing', 'customizing', 'installing', 'finalizing', 'done']
-const phaseRank = (p: CreatePhase): number => PHASE_ORDER.indexOf(p)
-
-/**
- * Best-effort, **purely cosmetic** mapping of the cumulative create log to the
- * furthest stage reached. Hardened so upstream output changes can never break
- * or stall the actual create:
- *  - It never reports `done` — completion is driven solely by the backend
- *    result, so reworded/removed "finished" lines can't strand the wizard.
- *  - Markers are loose substrings; missing them only softens the indicator
- *    (the spinner + elapsed timer + {@link fallbackPhase} still convey motion).
- *  - Wrapped so a parsing slip degrades gracefully instead of throwing.
- */
-function markerPhase(log: string): CreatePhase {
-  try {
-    const l = log.toLowerCase()
-    let reached: CreatePhase = 'preparing'
-    for (const def of CREATE_PHASES) {
-      if (def.markers.length && def.markers.some((m) => l.includes(m))) reached = def.id
-    }
-    return reached
-  } catch {
-    return 'preparing'
-  }
-}
-
-/**
- * Time-based floor so the indicator keeps advancing even if every upstream
- * output marker changes. Capped at `installing` (the dominant time sink) — it
- * never fabricates `finalizing`/`done`, which require a real signal/result.
- */
-function fallbackPhase(elapsedSec: number, running: boolean): CreatePhase {
-  if (!running) return 'preparing'
-  if (elapsedSec >= 10) return 'installing'
-  if (elapsedSec >= 3) return 'customizing'
-  return 'preparing'
-}
+/** The bundled data-app template a migration always scaffolds from. */
+const DATA_APP_TEMPLATE = 'fabricator-dataapp'
 
 /**
  * The full-window create-a-project experience. In `create` mode it runs a two-step
  * wizard — Details (name + template, ported from the old New Project dialog) then
  * Deploy (pick a Fabric workspace via the shared {@link DeploymentCreateForm}). In
  * `deploy` mode it shows only the Deploy step, used by the chat hard-gate CTA to
- * guide a freshly created project to its first deployment before chatting.
+ * guide a freshly created project to its first deployment before chatting. When a
+ * {@link MigrateSetup} is supplied, the Details step instead runs a Power BI report
+ * migration (standard create + install, then a report-code fetch) before Deploy.
  */
 export default function CreateProjectScreen({
   mode,
@@ -117,7 +95,8 @@ export default function CreateProjectScreen({
   onDeploy,
   onContinueWithoutDeploy,
   onSignedIn,
-  deploying = false
+  deploying = false,
+  migrate
 }: Props): JSX.Element {
   // The native preview webview floats above HTML; suppress it while this covers the body.
   useSuppressPreview()
@@ -128,7 +107,8 @@ export default function CreateProjectScreen({
   // ----- Details step (ported from NewProjectModal) -----
   const [templates, setTemplates] = useState<TemplateInfo[]>([])
   const [loadingTemplates, setLoadingTemplates] = useState(true)
-  const [name, setName] = useState('')
+  // In migrate mode the app name defaults to the report's display name (editable).
+  const [name, setName] = useState(() => migrate?.projectName ?? '')
   const [source, setSource] = useState<'builtin' | 'community'>('builtin')
   const [template, setTemplate] = useState('')
   const [gallery, setGallery] = useState<CommunityGallery | null>(null)
@@ -140,12 +120,18 @@ export default function CreateProjectScreen({
   const [templateName, setTemplateName] = useState('')
   const [busy, setBusy] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const [log, setLog] = useState('')
-  const [showDetails, setShowDetails] = useState(false)
-  const [startedAt, setStartedAt] = useState<number | null>(null)
-  const [now, setNow] = useState(0)
   const [done, setDone] = useState(false)
-  const logRef = useRef<HTMLPreElement>(null)
+
+  // ----- Migrate sub-step (report-code fetch, between create and deploy) -----
+  const [fetching, setFetching] = useState(false)
+  // The migrate fetch runs two visible sub-steps: download the report + model
+  // code, then export the report to PDF and rasterize each page into a chat
+  // attachment. Each tracks its own status/detail so both render as a row.
+  const [codeSub, setCodeSub] = useState<MigrateSub>({ detail: '', status: 'pending' })
+  const [pagesSub, setPagesSub] = useState<MigrateSub>({ detail: '', status: 'pending' })
+  // The project scaffolded by a migrate create, kept so a fetch failure or Cancel
+  // can roll it back (and a fetch retry reuses it instead of re-scaffolding).
+  const createdProjectRef = useRef<StudioProject | null>(null)
 
   // ----- Deploy step -----
   const [wsResult, setWsResult] = useState<FabricWorkspacesResult | null>(null)
@@ -211,27 +197,6 @@ export default function CreateProjectScreen({
     }
   }, [source, customMode])
 
-  useEffect(() => {
-    const off = window.api.onProcLog((e) => {
-      if (e.channel === 'create:project') setLog((prev) => prev + e.data)
-    })
-    return off
-  }, [])
-
-  useEffect(() => {
-    if (logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight
-  }, [log, showDetails])
-
-  // Tick a 1s elapsed clock while a create is in flight. This is the strongest
-  // "still working" cue during the output-silent npm install — and it's
-  // independent of any scaffolder/CLI log wording, so it survives upstream
-  // output changes.
-  useEffect(() => {
-    if (!busy || startedAt == null) return
-    const id = window.setInterval(() => setNow(Date.now()), 1000)
-    return () => window.clearInterval(id)
-  }, [busy, startedAt])
-
   // Fetch workspaces when the Deploy step first appears.
   useEffect(() => {
     if (step === 'deploy' && !wsResult && !loadingWs) void loadWorkspaces()
@@ -242,11 +207,7 @@ export default function CreateProjectScreen({
   async function create(): Promise<void> {
     setBusy(true)
     setError(null)
-    setLog('')
     setDone(false)
-    setShowDetails(false)
-    setStartedAt(Date.now())
-    setNow(Date.now())
     try {
       let tmpl: string
       let tmplName: string | undefined
@@ -272,13 +233,103 @@ export default function CreateProjectScreen({
         setStep('deploy')
       } else {
         setError(result.error ?? 'Project creation failed.')
-        // Surface the raw output so the real failure (not just our summary) is
-        // visible without an extra click.
-        setShowDetails(true)
       }
     } finally {
       setBusy(false)
     }
+  }
+
+  // ----- Migrate: run the *standard* create (data-app template, named by the
+  // Details field, with the same numbered-name collision retry a normal create
+  // uses), advance to the Migrate step, download the report's code into the
+  // project, then advance to the Deploy step. -----
+
+  async function runFetch(project: StudioProject): Promise<boolean> {
+    if (!migrate) return true
+    setFetching(true)
+    setError(null)
+    setCodeSub({ detail: 'Getting your report’s code…', status: 'running' })
+    setPagesSub({ detail: 'Waiting for the report code…', status: 'pending' })
+    const err = await migrate.onFetchReportCode(project, (phase, detail, status) => {
+      const next: MigrateSub = { detail, status: status ?? 'running' }
+      if (phase === 'code') setCodeSub(next)
+      else setPagesSub(next)
+    })
+    setFetching(false)
+    if (err) {
+      setError(err)
+      // Attribute the failure to whichever sub-step was still running.
+      setCodeSub((s) => (s.status === 'running' ? { detail: err, status: 'error' } : s))
+      setPagesSub((s) => (s.status === 'running' ? { detail: err, status: 'error' } : s))
+      return false
+    }
+    // Defensive: settle any sub-step the reporter left non-terminal on success.
+    setCodeSub((s) => (s.status === 'done' ? s : { ...s, status: 'done' }))
+    setPagesSub((s) =>
+      s.status === 'running' ? { ...s, status: 'done' } : s.status === 'pending' ? { detail: 'Skipped.', status: 'skipped' } : s
+    )
+    return true
+  }
+
+  async function createMigrate(): Promise<void> {
+    if (!migrate) return
+    const base = name.trim() || migrate.projectName
+    setBusy(true)
+    setError(null)
+    setDone(false)
+    let project: StudioProject | null = null
+    try {
+      let created = await window.api.projects.create({
+        name: base,
+        template: DATA_APP_TEMPLATE
+      })
+      for (
+        let n = 2;
+        !created.ok && created.error && /already exists/i.test(created.error) && n <= 50;
+        n++
+      ) {
+        created = await window.api.projects.create({
+          name: `${base} ${n}`,
+          template: DATA_APP_TEMPLATE
+        })
+      }
+      if (!created.ok || !created.project) {
+        setError(created.error ?? 'Could not create a project for the report.')
+        return
+      }
+      project = created.project
+      createdProjectRef.current = project
+      setDone(true)
+      setCreatedName(project.name)
+      onCreated?.(created)
+    } finally {
+      setBusy(false)
+    }
+    if (!project) return
+    setStep('migrate')
+    if (await runFetch(project)) setStep('deploy')
+  }
+
+  // Retry the failed part only: a failed create re-scaffolds; a failed fetch (the
+  // project already exists) just re-downloads the report code.
+  async function retryMigrate(): Promise<void> {
+    const existing = createdProjectRef.current
+    if (existing) {
+      if (await runFetch(existing)) setStep('deploy')
+    } else {
+      await createMigrate()
+    }
+  }
+
+  // Abandon a migration: roll back the scaffolded project (if any) so no empty
+  // folder is left behind, then leave the flow.
+  async function cancelMigrate(): Promise<void> {
+    const proj = createdProjectRef.current
+    if (proj && migrate) {
+      createdProjectRef.current = null
+      await migrate.onRollback(proj)
+    }
+    onCancel()
   }
 
   const slug = name
@@ -288,40 +339,45 @@ export default function CreateProjectScreen({
     .replace(/^-+|-+$/g, '')
 
   const urlValid = /^(https?:\/\/|git@|git\+)/i.test(url.trim())
-  const canCreate =
-    Boolean(slug) &&
-    (source === 'builtin' ? Boolean(template) : customMode ? urlValid : Boolean(selectedEntry))
+  const canCreate = migrate
+    ? Boolean(slug)
+    : Boolean(slug) &&
+      (source === 'builtin' ? Boolean(template) : customMode ? urlValid : Boolean(selectedEntry))
 
   // ----- Create progress (cosmetic; completion is driven by `done`) -----
-  const elapsedSec = startedAt ? Math.max(0, Math.floor((now - startedAt) / 1000)) : 0
-  const elapsedLabel = `${Math.floor(elapsedSec / 60)}:${String(elapsedSec % 60).padStart(2, '0')}`
-  const detectedPhase = markerPhase(log)
-  const fallback = fallbackPhase(elapsedSec, busy)
-  // Never regress: take the furthest of the parsed marker and the time floor.
-  const phase: CreatePhase = done
-    ? 'done'
-    : phaseRank(detectedPhase) >= phaseRank(fallback)
-      ? detectedPhase
-      : fallback
-  const activeIdx =
-    phase === 'done' ? CREATE_PHASES.length : CREATE_PHASES.findIndex((p) => p.id === phase)
-  const activePhaseLabel =
-    phase === 'done' ? 'Project ready' : (CREATE_PHASES[activeIdx]?.label ?? 'Preparing')
   const createFailed = !busy && !done && Boolean(error)
-  const showProgress = busy || Boolean(log)
+  // A migration's report-code fetch failed *after* a successful create — surfaced
+  // inline on the fetch row (with a Try again that re-downloads, not re-creates).
+  const fetchFailed = Boolean(migrate) && done && !fetching && Boolean(error)
+
+  // Wizard steps for the header progress rail (migrate inserts a Migrate step).
+  const stepOrder: Step[] = migrate ? ['details', 'migrate', 'deploy'] : ['details', 'deploy']
+  const curStepIdx = stepOrder.indexOf(step)
+  const stepClass = (s: Step): string => {
+    const i = stepOrder.indexOf(s)
+    return `create-step${
+      i === curStepIdx ? ' create-step--active' : i < curStepIdx ? ' create-step--done' : ''
+    }`
+  }
 
   const heading =
     step === 'deploy'
       ? mode === 'create'
         ? 'Deploy your app'
         : 'Create your first deployment'
-      : 'New Rayfin project'
+      : migrate
+        ? 'Migrate Power BI report'
+        : 'New Rayfin project'
   const sub =
     step === 'deploy'
       ? `Publish ${createdName || 'your app'} to a Fabric workspace to start building with chat.`
-      : busy
-        ? `Setting up ${name.trim() || 'your app'}…`
-        : 'Name your app and pick a template to start from.'
+      : step === 'migrate'
+        ? `Getting ${createdName || 'the report'}’s code…`
+        : busy
+          ? `Setting up ${name.trim() || 'your app'}…`
+          : migrate
+            ? 'Name your app — we’ll migrate the report into it.'
+            : 'Name your app and pick a template to start from.'
   const skipLabel = mode === 'deploy' ? 'Maybe later' : 'Continue without deploying →'
 
   return (
@@ -334,16 +390,18 @@ export default function CreateProjectScreen({
           </div>
           {mode === 'create' && (
             <ol className="create-steps" aria-label="Progress">
-              <li
-                className={`create-step${
-                  step === 'details' ? ' create-step--active' : ' create-step--done'
-                }`}
-              >
+              <li className={stepClass('details')}>
                 <span className="create-step-no">1</span>
                 <span className="create-step-label">Details</span>
               </li>
-              <li className={`create-step${step === 'deploy' ? ' create-step--active' : ''}`}>
-                <span className="create-step-no">2</span>
+              {migrate && (
+                <li className={stepClass('migrate')}>
+                  <span className="create-step-no">2</span>
+                  <span className="create-step-label">Migrate</span>
+                </li>
+              )}
+              <li className={stepClass('deploy')}>
+                <span className="create-step-no">{migrate ? 3 : 2}</span>
                 <span className="create-step-label">Deploy</span>
               </li>
             </ol>
@@ -354,7 +412,7 @@ export default function CreateProjectScreen({
           <>
             <div className="create-body">
               <label className={`field${busy ? ' create-field-hidden' : ''}`}>
-                <span className="field-label">Project name</span>
+                <span className="field-label">App name</span>
                 <input
                   className="field-input"
                   type="text"
@@ -374,253 +432,272 @@ export default function CreateProjectScreen({
                 )}
               </label>
 
-              <div className={`field${busy ? ' create-field-hidden' : ''}`}>
-                <span className="field-label">Template</span>
-                <div className="seg">
-                  <button
-                    type="button"
-                    disabled={busy}
-                    className={`seg-btn${source === 'builtin' ? ' seg-btn--active' : ''}`}
-                    onClick={() => setSource('builtin')}
-                  >
-                    Featured
-                  </button>
-                  <button
-                    type="button"
-                    disabled={busy}
-                    className={`seg-btn${source === 'community' ? ' seg-btn--active' : ''}`}
-                    onClick={() => setSource('community')}
-                  >
-                    Community
-                  </button>
-                </div>
+              {!migrate && (
+                <>
+                  <div className={`field${busy ? ' create-field-hidden' : ''}`}>
+                    <span className="field-label">Template</span>
+                    <div className="seg">
+                      <button
+                        type="button"
+                        disabled={busy}
+                        className={`seg-btn${source === 'builtin' ? ' seg-btn--active' : ''}`}
+                        onClick={() => setSource('builtin')}
+                      >
+                        Featured
+                      </button>
+                      <button
+                        type="button"
+                        disabled={busy}
+                        className={`seg-btn${source === 'community' ? ' seg-btn--active' : ''}`}
+                        onClick={() => setSource('community')}
+                      >
+                        Community
+                      </button>
+                    </div>
 
-                <p className="template-caption">
-                  {source === 'builtin'
-                    ? 'Curated, ready-to-run starting points — each deploys straight to a Fabric test workspace, then you keep building with chat.'
-                    : 'Start from any community template published in an awesome-rayfin GitHub repo.'}
-                </p>
+                    <p className="template-caption">
+                      {source === 'builtin'
+                        ? 'Curated, ready-to-run starting points — each deploys straight to a Fabric test workspace, then you keep building with chat.'
+                        : 'Start from any community template published in an awesome-rayfin GitHub repo.'}
+                    </p>
 
-                {source === 'builtin' ? (
-                  loadingTemplates ? (
-                    <div className="template-grid" aria-busy="true">
-                      {Array.from({ length: 3 }).map((_, i) => (
-                        <div key={i} className="template-card template-card--skel">
-                          <span className="skel-line skel-line--title" />
-                          <span className="skel-line" />
-                          <span className="skel-line skel-line--short" />
+                    {source === 'builtin' ? (
+                      loadingTemplates ? (
+                        <div className="template-grid" aria-busy="true">
+                          {Array.from({ length: 3 }).map((_, i) => (
+                            <div key={i} className="template-card template-card--skel">
+                              <span className="skel-line skel-line--title" />
+                              <span className="skel-line" />
+                              <span className="skel-line skel-line--short" />
+                            </div>
+                          ))}
                         </div>
-                      ))}
-                    </div>
-                  ) : (
-                    <div className="template-grid">
-                      {templates.map((t) => (
-                        <button
-                          key={t.name}
-                          type="button"
-                          disabled={busy}
-                          className={`template-card${template === t.name ? ' template-card--active' : ''}`}
-                          onClick={() => setTemplate(t.name)}
-                        >
-                          <span className="template-card-name">{t.displayName}</span>
-                          {t.defaultPreviewMode === 'fabric' && (
-                            <span
-                              className="template-card-badge"
-                              title="Opens embedded in the Fabric portal view by default — you can switch to the direct view any time."
+                      ) : (
+                        <div className="template-grid">
+                          {templates.map((t) => (
+                            <button
+                              key={t.name}
+                              type="button"
+                              disabled={busy}
+                              className={`template-card${template === t.name ? ' template-card--active' : ''}`}
+                              onClick={() => setTemplate(t.name)}
                             >
-                              Opens in Fabric view
-                            </span>
-                          )}
-                          <span className="template-card-desc">{t.description}</span>
-                        </button>
-                      ))}
-                    </div>
-                  )
-                ) : customMode ? (
-                  <div className="template-url">
-                    <input
-                      className="field-input"
-                      type="text"
-                      value={url}
-                      placeholder="https://github.com/owner/awesome-rayfin-template"
-                      spellCheck={false}
-                      disabled={busy}
-                      onChange={(e) => setUrl(e.target.value)}
-                    />
-                    <span className="field-hint">
-                      A git or tarball URL for a community (awesome-rayfin) template.
-                    </span>
-                    <input
-                      className="field-input"
-                      type="text"
-                      value={templateName}
-                      placeholder="Template name (optional, for multi-template repos)"
-                      spellCheck={false}
-                      disabled={busy}
-                      onChange={(e) => setTemplateName(e.target.value)}
-                    />
-                    {url.trim() && !urlValid && (
-                      <span className="field-hint field-hint--warn">
-                        Enter a valid http(s) or git URL.
-                      </span>
-                    )}
-                    <button
-                      type="button"
-                      className="link-btn"
-                      disabled={busy}
-                      onClick={() => setCustomMode(false)}
-                    >
-                      ← Back to the gallery
-                    </button>
-                  </div>
-                ) : loadingGallery ? (
-                  <div className="template-grid" aria-busy="true">
-                    {Array.from({ length: 4 }).map((_, i) => (
-                      <div key={i} className="template-card template-card--skel">
-                        <span className="skel-line skel-line--title" />
-                        <span className="skel-line" />
-                        <span className="skel-line skel-line--short" />
-                      </div>
-                    ))}
-                  </div>
-                ) : galleryError ? (
-                  <div className="gallery-empty">
-                    <p className="gallery-empty-msg">{galleryError}</p>
-                    <div className="gallery-empty-actions">
-                      <button
-                        type="button"
-                        className="btn btn--sm"
-                        disabled={busy}
-                        onClick={() => void loadGallery()}
-                      >
-                        Try again
-                      </button>
-                      <button
-                        type="button"
-                        className="link-btn"
-                        disabled={busy}
-                        onClick={() => setCustomMode(true)}
-                      >
-                        Use a custom URL
-                      </button>
-                    </div>
-                  </div>
-                ) : (
-                  <>
-                    <div className="template-grid">
-                      {gallery?.templates.map((t) => (
-                        <button
-                          key={keyOf(t)}
-                          type="button"
-                          disabled={busy}
-                          className={`template-card${communitySel === keyOf(t) ? ' template-card--active' : ''}`}
-                          onClick={() => setCommunitySel(keyOf(t))}
-                        >
-                          <span className="template-card-name">{t.name}</span>
-                          <span className="template-card-desc">{t.description}</span>
-                        </button>
-                      ))}
-                    </div>
-                    <div className="gallery-footer">
-                      <span className="field-hint">
-                        From{' '}
-                        <code>
-                          {gallery?.displayName || gallery?.repoUrl.replace(/^https?:\/\//, '')}
-                        </code>
-                      </span>
-                      <button
-                        type="button"
-                        className="link-btn"
-                        disabled={busy}
-                        onClick={() => setCustomMode(true)}
-                      >
-                        Use a custom URL
-                      </button>
-                    </div>
-                  </>
-                )}
-              </div>
-
-              {showProgress && (
-                <div className="create-progress" aria-busy={busy}>
-                  <span className="sr-only" role="status" aria-live="polite">
-                    {busy ? activePhaseLabel : done ? 'Project ready' : ''}
-                  </span>
-                  <ol className="create-phases">
-                    {CREATE_PHASES.map((p, i) => {
-                      const state =
-                        phase === 'done' || i < activeIdx
-                          ? 'done'
-                          : i === activeIdx
-                            ? 'active'
-                            : 'pending'
-                      return (
-                        <li
-                          key={p.id}
-                          className={`create-phase create-phase--${state}${
-                            createFailed && state === 'active' ? ' create-phase--failed' : ''
-                          }`}
-                        >
-                          <span className="create-phase-ico" aria-hidden="true">
-                            {state === 'active' ? (
-                              busy ? (
-                                <span className="ws-spinner" />
-                              ) : createFailed ? (
-                                '✕'
-                              ) : null
-                            ) : state === 'done' ? (
-                              '✓'
-                            ) : null}
-                          </span>
-                          <span className="create-phase-text">
-                            <span className="create-phase-label">{p.label}</span>
-                            {p.id === 'installing' && state === 'active' && (
-                              <span className="create-phase-hint">
-                                {elapsedSec > 75
-                                  ? 'Still working — large dependency trees take a little longer.'
-                                  : p.hint}
-                              </span>
-                            )}
-                          </span>
-                        </li>
+                              <span className="template-card-name">{t.displayName}</span>
+                              {t.defaultPreviewMode === 'fabric' && (
+                                <span
+                                  className="template-card-badge"
+                                  title="Opens embedded in the Fabric portal view by default — you can switch to the direct view any time."
+                                >
+                                  Opens in Fabric view
+                                </span>
+                              )}
+                              <span className="template-card-desc">{t.description}</span>
+                            </button>
+                          ))}
+                        </div>
                       )
-                    })}
-                  </ol>
-
-                  <div className="create-progress-meta">
-                    <span className="create-elapsed" aria-hidden="true">
-                      {busy ? `${elapsedLabel} elapsed` : done ? 'Done' : ''}
-                    </span>
-                    <button
-                      type="button"
-                      className="link-btn create-progress-toggle"
-                      onClick={() => setShowDetails((v) => !v)}
-                    >
-                      {showDetails ? 'Hide details' : 'Show details'}
-                    </button>
+                    ) : customMode ? (
+                      <div className="template-url">
+                        <input
+                          className="field-input"
+                          type="text"
+                          value={url}
+                          placeholder="https://github.com/owner/awesome-rayfin-template"
+                          spellCheck={false}
+                          disabled={busy}
+                          onChange={(e) => setUrl(e.target.value)}
+                        />
+                        <span className="field-hint">
+                          A git or tarball URL for a community (awesome-rayfin) template.
+                        </span>
+                        <input
+                          className="field-input"
+                          type="text"
+                          value={templateName}
+                          placeholder="Template name (optional, for multi-template repos)"
+                          spellCheck={false}
+                          disabled={busy}
+                          onChange={(e) => setTemplateName(e.target.value)}
+                        />
+                        {url.trim() && !urlValid && (
+                          <span className="field-hint field-hint--warn">
+                            Enter a valid http(s) or git URL.
+                          </span>
+                        )}
+                        <button
+                          type="button"
+                          className="link-btn"
+                          disabled={busy}
+                          onClick={() => setCustomMode(false)}
+                        >
+                          ← Back to the gallery
+                        </button>
+                      </div>
+                    ) : loadingGallery ? (
+                      <div className="template-grid" aria-busy="true">
+                        {Array.from({ length: 4 }).map((_, i) => (
+                          <div key={i} className="template-card template-card--skel">
+                            <span className="skel-line skel-line--title" />
+                            <span className="skel-line" />
+                            <span className="skel-line skel-line--short" />
+                          </div>
+                        ))}
+                      </div>
+                    ) : galleryError ? (
+                      <div className="gallery-empty">
+                        <p className="gallery-empty-msg">{galleryError}</p>
+                        <div className="gallery-empty-actions">
+                          <button
+                            type="button"
+                            className="btn btn--sm"
+                            disabled={busy}
+                            onClick={() => void loadGallery()}
+                          >
+                            Try again
+                          </button>
+                          <button
+                            type="button"
+                            className="link-btn"
+                            disabled={busy}
+                            onClick={() => setCustomMode(true)}
+                          >
+                            Use a custom URL
+                          </button>
+                        </div>
+                      </div>
+                    ) : (
+                      <>
+                        <div className="template-grid">
+                          {gallery?.templates.map((t) => (
+                            <button
+                              key={keyOf(t)}
+                              type="button"
+                              disabled={busy}
+                              className={`template-card${communitySel === keyOf(t) ? ' template-card--active' : ''}`}
+                              onClick={() => setCommunitySel(keyOf(t))}
+                            >
+                              <span className="template-card-name">{t.name}</span>
+                              <span className="template-card-desc">{t.description}</span>
+                            </button>
+                          ))}
+                        </div>
+                        <div className="gallery-footer">
+                          <span className="field-hint">
+                            From{' '}
+                            <code>
+                              {gallery?.displayName || gallery?.repoUrl.replace(/^https?:\/\//, '')}
+                            </code>
+                          </span>
+                          <button
+                            type="button"
+                            className="link-btn"
+                            disabled={busy}
+                            onClick={() => setCustomMode(true)}
+                          >
+                            Use a custom URL
+                          </button>
+                        </div>
+                      </>
+                    )}
                   </div>
-
-                  {showDetails && (
-                    <pre
-                      className="log-console log-console--sm create-progress-details"
-                      ref={logRef}
-                    >
-                      {log || 'Starting…'}
-                    </pre>
-                  )}
-                </div>
+                </>
               )}
+
+              <CreateProgress running={busy} done={done} failed={createFailed} />
 
               {error && <div className="alert alert--error">{error}</div>}
             </div>
 
             <footer className="create-foot">
-              <button className="btn btn--ghost" onClick={onCancel} disabled={busy}>
+              {migrate ? (
+                <>
+                  <button
+                    className="btn btn--ghost"
+                    onClick={() => void cancelMigrate()}
+                    disabled={busy}
+                  >
+                    Cancel
+                  </button>
+                  {createFailed ? (
+                    <button
+                      className="btn btn--primary"
+                      onClick={() => void retryMigrate()}
+                      disabled={busy}
+                    >
+                      Try again
+                    </button>
+                  ) : (
+                    <button
+                      className="btn btn--primary"
+                      onClick={() => void createMigrate()}
+                      disabled={busy || !canCreate}
+                    >
+                      {busy ? 'Creating…' : 'Create app'}
+                    </button>
+                  )}
+                </>
+              ) : (
+                <>
+                  <button className="btn btn--ghost" onClick={onCancel} disabled={busy}>
+                    Cancel
+                  </button>
+                  <button
+                    className="btn btn--primary"
+                    onClick={create}
+                    disabled={busy || !canCreate}
+                  >
+                    {busy ? 'Creating…' : 'Create project'}
+                  </button>
+                </>
+              )}
+            </footer>
+          </>
+        ) : step === 'migrate' ? (
+          <>
+            <div className="create-body">
+              {(
+                [
+                  { key: 'code', label: 'Get report code (definition + semantic model)', sub: codeSub },
+                  { key: 'pages', label: 'Capture report pages (PDF → images)', sub: pagesSub }
+                ] as const
+              ).map(({ key, label, sub }) => (
+                <div key={key} className={`migrate-fetch migrate-fetch--${sub.status}`}>
+                  <span className="migrate-fetch-ico" aria-hidden="true">
+                    {sub.status === 'error'
+                      ? '✕'
+                      : sub.status === 'done'
+                        ? '✓'
+                        : sub.status === 'skipped'
+                          ? '–'
+                          : sub.status === 'pending'
+                            ? '·'
+                            : <span className="ws-spinner" />}
+                  </span>
+                  <span className="migrate-fetch-body">
+                    <span className="migrate-fetch-label">{label}</span>
+                    <span className="migrate-fetch-detail">{sub.detail}</span>
+                  </span>
+                </div>
+              ))}
+            </div>
+
+            <footer className="create-foot">
+              <button
+                className="btn btn--ghost"
+                onClick={() => void cancelMigrate()}
+                disabled={fetching}
+              >
                 Cancel
               </button>
-              <button className="btn btn--primary" onClick={create} disabled={busy || !canCreate}>
-                {busy ? 'Creating…' : 'Create project'}
-              </button>
+              {fetchFailed && (
+                <button
+                  className="btn btn--primary"
+                  onClick={() => void retryMigrate()}
+                  disabled={fetching}
+                >
+                  Try again
+                </button>
+              )}
             </footer>
           </>
         ) : (

--- a/src/renderer/src/components/HomeView.test.tsx
+++ b/src/renderer/src/components/HomeView.test.tsx
@@ -15,6 +15,7 @@ function baseProps(): ComponentProps<typeof HomeView> {
     onNewProject: vi.fn(),
     onOpenExisting: vi.fn(),
     onCloneFromGitHub: vi.fn(),
+    onMigratePowerBIReport: vi.fn(),
     onChangeWorkspaceRoot: vi.fn()
   }
 }
@@ -29,12 +30,14 @@ describe('HomeView project launcher', () => {
     fireEvent.click(screen.getByRole('button', { name: /new project/i }))
     fireEvent.click(screen.getByRole('button', { name: /open folder/i }))
     fireEvent.click(screen.getByRole('button', { name: /clone from github/i }))
+    fireEvent.click(screen.getByRole('button', { name: /migrate power bi report/i }))
 
     expect(props.onNewProject).toHaveBeenCalledTimes(1)
     expect(props.onOpenExisting).toHaveBeenCalledTimes(1)
     expect(props.onCloneFromGitHub).toHaveBeenCalledTimes(1)
+    expect(props.onMigratePowerBIReport).toHaveBeenCalledTimes(1)
     expect(screen.queryByRole('button', { name: /open existing/i })).toBeNull()
-    expect(document.querySelectorAll('.home-action-icon > svg')).toHaveLength(3)
+    expect(document.querySelectorAll('.home-action-icon > svg')).toHaveLength(4)
   })
 
   it('uses separate native controls to open and manage a recent project', () => {

--- a/src/renderer/src/components/HomeView.tsx
+++ b/src/renderer/src/components/HomeView.tsx
@@ -1,6 +1,6 @@
 import type { StudioProject } from '@shared/ipc'
 import { FabricatorMark } from './FabricatorMark'
-import { AddIcon, BranchIcon, FolderIcon, GearIcon } from './icons'
+import { AddIcon, BranchIcon, FolderIcon, GearIcon, ReportIcon } from './icons'
 
 interface Props {
   /** All known projects, most-recently-used first. */
@@ -19,6 +19,8 @@ interface Props {
   onOpenExisting: () => void
   /** Start the sign-in/browse/clone flow. */
   onCloneFromGitHub: () => void
+  /** Open the "pick a workspace, then a report" Power BI migration flow. */
+  onMigratePowerBIReport: () => void
   onChangeWorkspaceRoot: () => void
 }
 
@@ -33,6 +35,7 @@ export default function HomeView({
   onNewProject,
   onOpenExisting,
   onCloneFromGitHub,
+  onMigratePowerBIReport,
   onChangeWorkspaceRoot
 }: Props): JSX.Element {
   const projectCount = `${projects.length} project${projects.length === 1 ? '' : 's'}`
@@ -88,6 +91,15 @@ export default function HomeView({
               <span className="home-action-text">
                 <span className="home-action-label">Clone from GitHub</span>
                 <span className="home-action-hint">Bring a repository into Fabricator</span>
+              </span>
+            </button>
+            <button type="button" className="home-action" onClick={onMigratePowerBIReport}>
+              <span className="home-action-icon" aria-hidden="true">
+                <ReportIcon className="home-action-svg" />
+              </span>
+              <span className="home-action-text">
+                <span className="home-action-label">Migrate Power BI Report</span>
+                <span className="home-action-hint">Bring a Power BI report into Fabricator</span>
               </span>
             </button>
           </div>

--- a/src/renderer/src/components/MigratePowerBIReportModal.tsx
+++ b/src/renderer/src/components/MigratePowerBIReportModal.tsx
@@ -1,0 +1,284 @@
+import { useEffect, useId, useState } from 'react'
+import type { FabricReport, FabricWorkspacesResult } from '@shared/ipc'
+import { useSuppressPreview } from '../overlay'
+import { useModalFocus } from '../modalFocus'
+import { Codicon } from './icons'
+
+interface Props {
+  onClose: () => void
+  /**
+   * The user picked a workspace + report to migrate. The parent closes this
+   * picker and hands the selection to the standard create flow (which scaffolds
+   * the data-app project, installs deps, fetches the report code, then deploys).
+   */
+  onSelect: (workspaceId: string, report: FabricReport) => void
+}
+
+/**
+ * The "Migrate a Power BI report" picker: pick a Fabric workspace, then a report
+ * inside it. Both lists are loaded live from Fabric — workspaces via
+ * `fabric.listWorkspaces`, and the report list via `fabric.listReports`
+ * whenever the chosen workspace changes. Confirming hands the selection to
+ * `onSelect`; the actual create + fetch + deploy runs in the shared create flow.
+ */
+export default function MigratePowerBIReportModal({ onClose, onSelect }: Props): JSX.Element {
+  useSuppressPreview()
+  const titleId = useId()
+  const dialogRef = useModalFocus<HTMLDivElement>()
+
+  const [wsResult, setWsResult] = useState<FabricWorkspacesResult | null>(null)
+  const [loadingWs, setLoadingWs] = useState(false)
+  const [workspaceId, setWorkspaceId] = useState('')
+
+  const [reports, setReports] = useState<FabricReport[]>([])
+  const [loadingReports, setLoadingReports] = useState(false)
+  const [reportsError, setReportsError] = useState<string | null>(null)
+  const [reportsNeedLogin, setReportsNeedLogin] = useState(false)
+  const [reportsRefresh, setReportsRefresh] = useState(0)
+  const [reportId, setReportId] = useState('')
+
+  const [signingIn, setSigningIn] = useState(false)
+  const [signInError, setSignInError] = useState<string | null>(null)
+
+  async function loadWorkspaces(): Promise<void> {
+    setLoadingWs(true)
+    try {
+      const res = await window.api.fabric.listWorkspaces()
+      setWsResult(res)
+    } finally {
+      setLoadingWs(false)
+    }
+  }
+
+  // Open the interactive Fabric sign-in window, then reload the lists. This is
+  // how a report-migrator authenticates from the Home screen (where no project
+  // is active); the write scope itself is only requested later, at migrate time.
+  async function signIn(): Promise<void> {
+    setSigningIn(true)
+    setSignInError(null)
+    try {
+      const res = await window.api.fabric.signIn()
+      if (!res.ok) {
+        setSignInError(res.error ?? 'Fabric sign-in failed.')
+        return
+      }
+      await loadWorkspaces()
+      if (workspaceId) setReportsRefresh((n) => n + 1)
+    } finally {
+      setSigningIn(false)
+    }
+  }
+
+  useEffect(() => {
+    void loadWorkspaces()
+  }, [])
+
+  // Load the reports for the chosen workspace. Re-runs on every workspace change
+  // and guards against a slow earlier request overwriting a newer selection.
+  useEffect(() => {
+    if (!workspaceId) {
+      setReports([])
+      setReportsError(null)
+      setReportsNeedLogin(false)
+      return
+    }
+    let cancelled = false
+    setLoadingReports(true)
+    setReportsError(null)
+    setReportsNeedLogin(false)
+    setReports([])
+    void window.api.fabric
+      .listReports(workspaceId)
+      .then((res) => {
+        if (cancelled) return
+        if (res.ok) {
+          setReports(res.reports ?? [])
+        } else {
+          setReportsNeedLogin(Boolean(res.needsLogin))
+          setReportsError(res.error ?? 'Could not load reports for this workspace.')
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setLoadingReports(false)
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [workspaceId, reportsRefresh])
+
+  useEffect(() => {
+    const onKey = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', onKey)
+    return () => window.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const workspaces = wsResult?.ok && wsResult.workspaces ? wsResult.workspaces : []
+  const canMigrate = Boolean(workspaceId && reportId)
+
+  // Shared "you need a Fabric session" prompt + sign-in button, reused by both
+  // the workspace and report lists when they come back needing a login.
+  const signInPrompt = (message: string): JSX.Element => (
+    <div className="ws-signin">
+      <p className="ws-empty-sub">{message}</p>
+      <button
+        type="button"
+        className="btn btn--sm btn--primary"
+        disabled={signingIn}
+        onClick={() => void signIn()}
+      >
+        {signingIn ? 'Signing in…' : 'Sign in to Microsoft Fabric'}
+      </button>
+      {signInError && <p className="ws-empty-sub">{signInError}</p>}
+    </div>
+  )
+
+  async function migrate(): Promise<void> {
+    const report = reports.find((r) => r.id === reportId)
+    if (!report) return
+    onSelect(workspaceId, report)
+  }
+
+  return (
+    <div className="modal-backdrop" onClick={onClose}>
+      <div
+        className="modal modal--sm"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        ref={dialogRef}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="modal-header">
+          <h2 id={titleId}>Migrate Power BI report</h2>
+          <button
+            type="button"
+            className="btn btn--sm btn--ghost"
+            aria-label="Close Power BI migration"
+            onClick={onClose}
+          >
+            <span className="codicon codicon-close" aria-hidden="true" />
+          </button>
+        </div>
+
+        <div className="modal-body">
+          <div className="dep-field">
+            <div className="dep-field-head">
+              <span className="dep-field-label">Workspace</span>
+              <button
+                className="ws-refresh"
+                type="button"
+                title="Refresh workspaces"
+                aria-label="Refresh workspaces"
+                disabled={loadingWs}
+                onClick={() => void loadWorkspaces()}
+              >
+                <Codicon name="refresh" />
+              </button>
+            </div>
+            {loadingWs ? (
+              <div className="ws-loading">
+                <span className="ws-spinner" />
+                Loading your workspaces…
+              </div>
+            ) : workspaces.length > 0 ? (
+              <select
+                className="ws-input"
+                aria-label="Workspace"
+                value={workspaceId}
+                onChange={(event) => {
+                  setWorkspaceId(event.target.value)
+                  setReportId('')
+                }}
+              >
+                <option value="">Select a workspace…</option>
+                {workspaces.map((w) => (
+                  <option key={w.id} value={w.id}>
+                    {w.displayName}
+                  </option>
+                ))}
+              </select>
+            ) : wsResult?.needsLogin ? (
+              signInPrompt('Sign in to Microsoft Fabric to list your workspaces.')
+            ) : (
+              <p className="ws-empty-sub">
+                Couldn’t load workspaces{wsResult?.error ? `: ${wsResult.error}` : '.'}
+              </p>
+            )}
+          </div>
+
+          <div className="dep-field">
+            <div className="dep-field-head">
+              <span className="dep-field-label">Report</span>
+              {workspaceId && (
+                <button
+                  className="ws-refresh"
+                  type="button"
+                  title="Refresh reports"
+                  aria-label="Refresh reports"
+                  disabled={loadingReports}
+                  onClick={() => setReportsRefresh((n) => n + 1)}
+                >
+                  <Codicon name="refresh" />
+                </button>
+              )}
+            </div>
+            {loadingReports ? (
+              <div className="ws-loading">
+                <span className="ws-spinner" />
+                Loading reports…
+              </div>
+            ) : reportsError ? (
+              reportsNeedLogin ? (
+                signInPrompt('Sign in to Microsoft Fabric to list this workspace’s reports.')
+              ) : (
+                <p className="ws-empty-sub">{`Couldn’t load reports: ${reportsError}`}</p>
+              )
+            ) : (
+              <>
+                <select
+                  className="ws-input"
+                  aria-label="Report"
+                  value={reportId}
+                  disabled={!workspaceId || reports.length === 0}
+                  onChange={(event) => setReportId(event.target.value)}
+                >
+                  <option value="">
+                    {!workspaceId
+                      ? 'Select a workspace first…'
+                      : reports.length === 0
+                        ? 'No Power BI reports in this workspace'
+                        : 'Select a report…'}
+                  </option>
+                  {reports.map((r) => (
+                    <option key={r.id} value={r.id}>
+                      {r.displayName}
+                    </option>
+                  ))}
+                </select>
+                {workspaceId && reports.length === 0 && (
+                  <p className="ws-empty-sub">This workspace has no Power BI reports to migrate.</p>
+                )}
+              </>
+            )}
+          </div>
+        </div>
+
+        <div className="modal-footer">
+          <button type="button" className="btn btn--ghost" onClick={onClose}>
+            Cancel
+          </button>
+          <button
+            type="button"
+            className="btn btn--primary"
+            disabled={!canMigrate}
+            onClick={() => void migrate()}
+          >
+            Migrate report
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/icons.tsx
+++ b/src/renderer/src/components/icons.tsx
@@ -73,6 +73,18 @@ export function FolderIcon(props: IconProps): JSX.Element {
   )
 }
 
+/** Bar chart — migrate a Power BI report. */
+export function ReportIcon(props: IconProps): JSX.Element {
+  return (
+    <Icon {...props}>
+      <path d="M3 3v18h18" />
+      <rect x="7" y="12" width="3" height="5" rx="0.5" />
+      <rect x="12" y="8" width="3" height="9" rx="0.5" />
+      <rect x="17" y="5" width="3" height="12" rx="0.5" />
+    </Icon>
+  )
+}
+
 /** Gear — Settings. */
 export function GearIcon(props: IconProps): JSX.Element {
   return (

--- a/src/renderer/src/reportPages.test.ts
+++ b/src/renderer/src/reportPages.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { pickVisiblePages, type PageSize } from './reportPages'
+
+/**
+ * Power BI PDF exports include the report's tooltip and hidden drill pages,
+ * which are far smaller than the real report pages. `pickVisiblePages` keeps
+ * only pages whose area is a meaningful fraction of the largest page, so the
+ * migrate hand-off attaches the pages a viewer actually sees.
+ */
+describe('pickVisiblePages', () => {
+  const full: PageSize = { width: 1280, height: 720 }
+  const tooltip: PageSize = { width: 320, height: 240 }
+
+  it('keeps the full-size report pages and drops tiny tooltip pages', () => {
+    const sizes = [full, full, tooltip, full]
+    expect(pickVisiblePages(sizes)).toEqual([1, 2, 4])
+  })
+
+  it('returns 1-based page numbers in document order', () => {
+    expect(pickVisiblePages([tooltip, full, tooltip, full])).toEqual([2, 4])
+  })
+
+  it('keeps every page when they are all the same size', () => {
+    expect(pickVisiblePages([full, full, full])).toEqual([1, 2, 3])
+  })
+
+  it('returns an empty list for no pages', () => {
+    expect(pickVisiblePages([])).toEqual([])
+  })
+
+  it('falls back to keeping all pages when sizes are degenerate', () => {
+    const zero: PageSize = { width: 0, height: 0 }
+    expect(pickVisiblePages([zero, zero])).toEqual([1, 2])
+  })
+
+  it('honours a custom minimum-area ratio', () => {
+    const sizes = [full, { width: 640, height: 360 }]
+    // The half-width page has 1/4 the area; a 0.5 threshold drops it.
+    expect(pickVisiblePages(sizes, 0.5)).toEqual([1])
+    // The default 0.25 threshold keeps it (area ratio == 0.25).
+    expect(pickVisiblePages(sizes)).toEqual([1, 2])
+  })
+})

--- a/src/renderer/src/reportPages.ts
+++ b/src/renderer/src/reportPages.ts
@@ -1,0 +1,133 @@
+/**
+ * Rasterizes an exported Power BI report PDF (see the Rust
+ * `fabric_export_report_pdf` command) into per-page PNG images that the migrate
+ * flow stages as chat attachments, so the agent has a pixel-accurate visual
+ * reference for each report page in addition to the PBIR definition.
+ *
+ * Rendering runs in the renderer (WebView2/Chromium) via pdf.js — no native
+ * dependency, cross-platform for free — and reuses the existing screenshot
+ * attachment plumbing (`window.api.screenshot.save` → {@link PendingShot}).
+ */
+import type { PendingShot } from './components/PreviewPane'
+
+/** A page's intrinsic size in PDF points (viewport at scale 1). */
+export interface PageSize {
+  width: number
+  height: number
+}
+
+/**
+ * Power BI's PDF export emits *every* page in the report, including the tiny
+ * tooltip and hidden drill-through pages that never appear in the main view.
+ * Keep only the "real" pages: those whose area is at least `minAreaRatio` of the
+ * largest page. Returns the kept page numbers (1-based, in document order).
+ *
+ * Falls back to keeping every page when sizes are missing or degenerate, so a
+ * surprising export shape never silently drops all pages.
+ */
+export function pickVisiblePages(sizes: PageSize[], minAreaRatio = 0.25): number[] {
+  if (sizes.length === 0) return []
+  const areas = sizes.map((s) => Math.max(0, s.width) * Math.max(0, s.height))
+  const maxArea = Math.max(...areas)
+  if (!(maxArea > 0)) return sizes.map((_, i) => i + 1)
+  const kept: number[] = []
+  areas.forEach((area, i) => {
+    if (area >= maxArea * minAreaRatio) kept.push(i + 1)
+  })
+  return kept.length > 0 ? kept : sizes.map((_, i) => i + 1)
+}
+
+/** Options controlling the rasterized page + thumbnail resolution. */
+export interface RenderOptions {
+  /** Target rendered page width in pixels (height follows the aspect ratio). */
+  maxWidth?: number
+  /** Target thumbnail width in pixels (shown in the chat bubble). */
+  thumbWidth?: number
+}
+
+/** Decode a base64 string (as returned across IPC) into raw bytes for pdf.js. */
+function base64ToBytes(b64: string): Uint8Array {
+  const bin = atob(b64)
+  const bytes = new Uint8Array(bin.length)
+  for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i)
+  return bytes
+}
+
+/** Downscale a rendered page canvas into a small thumbnail data URL. */
+function toThumb(source: HTMLCanvasElement, thumbWidth: number): string {
+  if (source.width <= thumbWidth) return source.toDataURL('image/png')
+  const ratio = thumbWidth / source.width
+  const tw = Math.max(1, Math.round(source.width * ratio))
+  const th = Math.max(1, Math.round(source.height * ratio))
+  const c = document.createElement('canvas')
+  c.width = tw
+  c.height = th
+  const cx = c.getContext('2d')
+  if (!cx) return source.toDataURL('image/png')
+  cx.drawImage(source, 0, 0, tw, th)
+  return c.toDataURL('image/png')
+}
+
+let workerConfigured = false
+
+/** Lazily import pdf.js and wire its worker (Vite resolves the URL at build). */
+async function loadPdfjs(): Promise<typeof import('pdfjs-dist')> {
+  const pdfjs = await import('pdfjs-dist')
+  if (!workerConfigured) {
+    pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+      'pdfjs-dist/build/pdf.worker.min.mjs',
+      import.meta.url
+    ).toString()
+    workerConfigured = true
+  }
+  return pdfjs
+}
+
+/**
+ * Render every visible page of the given base64 PDF to a PNG, persist each via
+ * `screenshot.save`, and return the {@link PendingShot}s (path + thumbnail) ready
+ * to attach to the migrate chat prompt. Best-effort: this is a visual aid, so
+ * callers should treat a throw as "skip page images", not a fatal error.
+ */
+export async function renderPdfToShots(
+  pdfBase64: string,
+  opts: RenderOptions = {}
+): Promise<PendingShot[]> {
+  const { maxWidth = 1400, thumbWidth = 240 } = opts
+  const pdfjs = await loadPdfjs()
+  const data = base64ToBytes(pdfBase64)
+  const doc = await pdfjs.getDocument({ data }).promise
+  try {
+    const sizes: PageSize[] = []
+    for (let i = 1; i <= doc.numPages; i++) {
+      const page = await doc.getPage(i)
+      const vp = page.getViewport({ scale: 1 })
+      sizes.push({ width: vp.width, height: vp.height })
+      page.cleanup()
+    }
+    const keep = pickVisiblePages(sizes)
+    const shots: PendingShot[] = []
+    for (const pageNum of keep) {
+      const page = await doc.getPage(pageNum)
+      const base = page.getViewport({ scale: 1 })
+      const scale = base.width > 0 ? maxWidth / base.width : 1
+      const viewport = page.getViewport({ scale })
+      const canvas = document.createElement('canvas')
+      canvas.width = Math.ceil(viewport.width)
+      canvas.height = Math.ceil(viewport.height)
+      const ctx = canvas.getContext('2d')
+      if (!ctx) {
+        page.cleanup()
+        continue
+      }
+      await page.render({ canvasContext: ctx, viewport }).promise
+      const dataUrl = canvas.toDataURL('image/png')
+      const path = await window.api.screenshot.save(dataUrl)
+      shots.push({ path, thumb: toThumb(canvas, thumbWidth) })
+      page.cleanup()
+    }
+    return shots
+  } finally {
+    await doc.destroy()
+  }
+}

--- a/src/renderer/src/reportPages.ts
+++ b/src/renderer/src/reportPages.ts
@@ -84,13 +84,18 @@ async function loadPdfjs(): Promise<typeof import('pdfjs-dist')> {
 }
 
 /**
- * Render every visible page of the given base64 PDF to a PNG, persist each via
- * `screenshot.save`, and return the {@link PendingShot}s (path + thumbnail) ready
- * to attach to the migrate chat prompt. Best-effort: this is a visual aid, so
- * callers should treat a throw as "skip page images", not a fatal error.
+ * Render every visible page of the given base64 PDF to a PNG, persist each into
+ * the project's `source-report/pages/` folder (via `fabric.saveReportPages`), and
+ * return the {@link PendingShot}s (path + thumbnail) ready to attach to the
+ * migrate chat prompt. Persisting in-project (rather than a temp dir the chat
+ * turn engine cleans up) means the build agent can re-open the page images on any
+ * later turn as a durable visual reference for theming — not just the first turn.
+ * Best-effort: this is a visual aid, so callers should treat a throw as "skip
+ * page images", not a fatal error.
  */
 export async function renderPdfToShots(
   pdfBase64: string,
+  projectPath: string,
   opts: RenderOptions = {}
 ): Promise<PendingShot[]> {
   const { maxWidth = 1400, thumbWidth = 240 } = opts
@@ -106,7 +111,8 @@ export async function renderPdfToShots(
       page.cleanup()
     }
     const keep = pickVisiblePages(sizes)
-    const shots: PendingShot[] = []
+    const dataUrls: string[] = []
+    const thumbs: string[] = []
     for (const pageNum of keep) {
       const page = await doc.getPage(pageNum)
       const base = page.getViewport({ scale: 1 })
@@ -121,12 +127,13 @@ export async function renderPdfToShots(
         continue
       }
       await page.render({ canvasContext: ctx, viewport }).promise
-      const dataUrl = canvas.toDataURL('image/png')
-      const path = await window.api.screenshot.save(dataUrl)
-      shots.push({ path, thumb: toThumb(canvas, thumbWidth) })
+      dataUrls.push(canvas.toDataURL('image/png'))
+      thumbs.push(toThumb(canvas, thumbWidth))
       page.cleanup()
     }
-    return shots
+    if (dataUrls.length === 0) return []
+    const paths = await window.api.fabric.saveReportPages(projectPath, dataUrls)
+    return paths.map((path, i) => ({ path, thumb: thumbs[i] }))
   } finally {
     await doc.destroy()
   }

--- a/src/renderer/src/screens/Workbench.tsx
+++ b/src/renderer/src/screens/Workbench.tsx
@@ -719,7 +719,7 @@ export default function Workbench({
         const pdf = await window.api.fabric.exportReportPdf(workspaceId, report.id, project.path)
         if (pdf.ok && pdf.pdfBase64) {
           onProgress('pages', 'Rendering report pages to images…')
-          pageShots = await renderPdfToShots(pdf.pdfBase64)
+          pageShots = await renderPdfToShots(pdf.pdfBase64, project.path)
           if (pageShots.length) {
             onProgress(
               'pages',
@@ -778,15 +778,27 @@ export default function Workbench({
             `(${modelError ?? 'no model reference found'}). Tell me the workspace + dataset id and ` +
             "I'll wire the app to query it — we should read from the existing model, not copy data."
 
-      // When we captured page images, tell the agent they're attached so it uses
-      // them as the visual ground truth for layout, colours, and chart types.
-      const pagesSection = pageShots.length
-        ? '\n\nI\'ve attached rendered images of each report page, exported straight from the ' +
-          'live report (its PDF export). **Use them to understand the report\'s look and feel** — ' +
-          'study the layout and grid, colour palette, typography, spacing, chart types, and ' +
-          'overall visual styling, and **apply the same styles to the app** so it closely matches ' +
-          'the original report (within what the Rayfin component set allows).'
-        : ''
+      // The report pages are persisted as images in `source-report/pages/` (and
+      // attached to this turn). Point the agent at them + the migrate skill so it
+      // treats the report's look as the design direction, up front.
+      const pageCount = pageShots.length
+      const pagesSection = pageCount
+        ? '\n\nEach page of the report has been rendered to an image in the ' +
+          `\`source-report/pages/\` folder (\`page-01.png\`${pageCount > 1 ? `…\`page-${String(pageCount).padStart(2, '0')}.png\`` : ''}), ` +
+          'and the same images are attached to this message. They are your visual ground ' +
+          "truth for the report's look and feel — open them and study the layout and grid, colour " +
+          'palette, typography, spacing, chart types, and overall styling. ' +
+          '(`source-report/report.pdf` is the full-resolution original if you need it.) ' +
+          '**This is a migration, so the report\'s existing look IS the design direction.** Before ' +
+          'applying the default theming guidance in `build-workflow`/`app-design`, read and follow ' +
+          '`.agents/skills/match-source-report/SKILL.md` — for a migration you establish the ' +
+          "report's palette, typography, and layout up front (in `src/global.css`) rather than " +
+          'picking a default and deferring theming, so the app closely matches the original report ' +
+          '(within what the Rayfin component set allows).'
+        : '\n\n**This is a migration, so the report\'s existing look IS the design direction.** Before ' +
+          'applying the default theming guidance in `build-workflow`/`app-design`, read and follow ' +
+          '`.agents/skills/match-source-report/SKILL.md` and match the report\'s palette, typography, ' +
+          'and layout from its `source-report/` definition.'
 
       const prompt =
         `I've imported a Power BI report ("${report.displayName}") from Fabric workspace ` +

--- a/src/renderer/src/screens/Workbench.tsx
+++ b/src/renderer/src/screens/Workbench.tsx
@@ -710,8 +710,9 @@ export default function Workbench({
       // Capture each report page as an image so the agent has a pixel-accurate
       // visual reference alongside the PBIR. Best-effort: image export is
       // tenant-blocked on many tenants (so we export a PDF and rasterize it with
-      // pdf.js), and PDF export needs a capacity-backed workspace — any failure is
-      // reported as "skipped", never fatal to the migration.
+      // pdf.js), and PDF export needs a capacity-backed workspace + a signed-in
+      // `az`. A real failure is surfaced to the user as a visible (red) sub-step
+      // but never blocks the migration — the app is still built from the PBIR.
       let pageShots: PendingShot[] = []
       onProgress('pages', 'Exporting the report to PDF…')
       try {
@@ -726,17 +727,26 @@ export default function Workbench({
               'done'
             )
           } else {
-            onProgress('pages', 'No visible report pages to capture.', 'skipped')
+            onProgress('pages', 'Export succeeded but had no visible pages to capture.', 'skipped')
           }
         } else {
+          const why = pdf.error ?? 'the Power BI export API was unavailable'
+          const cta = pdf.needsLogin
+            ? ' Run `az login`, then re-run the migration to capture the report pages.'
+            : ''
           onProgress(
             'pages',
-            pdf.error ?? 'Report-page export is unavailable for this report — skipped.',
-            'skipped'
+            `Couldn't export the report to PDF — continuing without page images. (${why})${cta}`,
+            'error'
           )
         }
       } catch (e) {
-        onProgress('pages', `Skipped (${e instanceof Error ? e.message : String(e)}).`, 'skipped')
+        onProgress(
+          'pages',
+          "Couldn't export the report to PDF — continuing without page images. " +
+            `(${e instanceof Error ? e.message : String(e)})`,
+          'error'
+        )
       }
 
       const reportList = reportFiles.map((f) => `- source-report/${f}`).join('\n')
@@ -771,9 +781,11 @@ export default function Workbench({
       // When we captured page images, tell the agent they're attached so it uses
       // them as the visual ground truth for layout, colours, and chart types.
       const pagesSection = pageShots.length
-        ? '\n\nI\'ve also attached rendered images of each report page (exported straight from ' +
-          'the live report). Use them as the visual reference for the layout, colours, chart ' +
-          'types, and overall look — match them as closely as the Rayfin component set allows.'
+        ? '\n\nI\'ve attached rendered images of each report page, exported straight from the ' +
+          'live report (its PDF export). **Use them to understand the report\'s look and feel** — ' +
+          'study the layout and grid, colour palette, typography, spacing, chart types, and ' +
+          'overall visual styling, and **apply the same styles to the app** so it closely matches ' +
+          'the original report (within what the Rayfin component set allows).'
         : ''
 
       const prompt =

--- a/src/renderer/src/screens/Workbench.tsx
+++ b/src/renderer/src/screens/Workbench.tsx
@@ -17,15 +17,18 @@ import {
   type ChatTurnResult,
   type DeployResult,
   type DevServerResult,
+  type FabricReport,
   type ProjectsState,
   type RayfinVersionInfo,
   type StudioProject
 } from '@shared/ipc'
 import CreateProjectScreen from '../components/CreateProjectScreen'
+import type { MigratePhase, MigrateSubStatus } from '../components/CreateProjectScreen'
 import CloneFromGitHubScreen from '../components/CloneFromGitHubScreen'
 import HomeView from '../components/HomeView'
 import ManageProjectModal from '../components/ManageProjectModal'
 import DeleteProjectModal from '../components/DeleteProjectModal'
+import MigratePowerBIReportModal from '../components/MigratePowerBIReportModal'
 import ConfirmModal from '../components/ConfirmModal'
 import SettingsModal from '../components/SettingsModal'
 import { applyUiScale, UI_SCALES } from '../theme'
@@ -33,6 +36,7 @@ import ChatPanel, { type UIChatMessage, type OutboundPrompt } from '../component
 import { planForStorage, planFromStorage } from '../chatPlan'
 import { useChatEventStore } from '../chatEventStore'
 import PreviewPane, { type DeployUiState, type PendingShot } from '../components/PreviewPane'
+import { renderPdfToShots } from '../reportPages'
 import DeploymentsControl from '../components/DeploymentsControl'
 import GitControl from '../components/GitControl'
 import ProjectDependencyGuard from '../components/ProjectDependencyGuard'
@@ -145,6 +149,22 @@ export default function Workbench({
   /** Launcher project-management and local-trash confirmation state. */
   const [managingProject, setManagingProject] = useState<StudioProject | null>(null)
   const [confirmDelete, setConfirmDelete] = useState<StudioProject | null>(null)
+  /** Whether the "Migrate Power BI report" workspace→report picker is open. */
+  const [showMigratePbi, setShowMigratePbi] = useState(false)
+  /**
+   * The report chosen in the picker, handed to the shared create flow. When set,
+   * `CreateProjectScreen` runs in migrate mode: create → fetch report code →
+   * deploy. Cleared once the flow completes or is cancelled.
+   */
+  const [migrateSel, setMigrateSel] = useState<{
+    workspaceId: string
+    report: FabricReport
+  } | null>(null)
+  /**
+   * The seed chat prompt built during the migrate fetch step, stashed so it can
+   * be dropped into the chat once the create → fetch → deploy flow finishes.
+   */
+  const migratePromptRef = useRef<(OutboundPrompt & { projectId: string }) | null>(null)
   /** Bumped whenever the working tree likely changed (deploy / chat turn). */
   const [gitRefresh, setGitRefresh] = useState(0)
   /** A user-initiated deploy paused by the "you have unpulled changes" warning. */
@@ -625,6 +645,190 @@ export default function Workbench({
       stage
     })
   }, [])
+
+  // Migrate step (fetch): with the Data App project already scaffolded by the
+  // shared create flow, grant Fabric access + download the chosen report's code
+  // into it. Downloads the report definition (PBIR, or classic report.json for
+  // legacy reports) into `source-report/` and best-effort its semantic model
+  // TMDL (schema + DAX reference) into `source-model/`. Runs through the *global*
+  // Rayfin CLI so it never waits on the new project's install; the first Fabric
+  // call may pop an interactive consent window for the write scope. Builds the
+  // seed chat prompt and stashes it (`migratePromptRef`) to drop into the chat
+  // once the flow reaches deploy. Returns an error string (fetch failed, create
+  // screen shows it + offers retry) or null on success.
+  const fetchMigrateReportCode = useCallback(
+    async (
+      project: StudioProject,
+      onProgress: (phase: MigratePhase, detail: string, status?: MigrateSubStatus) => void
+    ): Promise<string | null> => {
+      if (!migrateSel) return 'No report selected to migrate.'
+      const { workspaceId, report } = migrateSel
+
+      onProgress(
+        'code',
+        "Granting Fabric access & fetching your report's code… a Microsoft sign-in window may open."
+      )
+      const def = await window.api.fabric.reportDefinition(workspaceId, report.id, project.path)
+      if (!def.ok) {
+        return (
+          def.error ??
+          (def.needsLogin
+            ? 'Your Fabric session needs re-authentication — sign in again and retry.'
+            : 'Could not download the report definition.')
+        )
+      }
+      const reportFiles = def.files ?? []
+
+      // Best-effort: download the semantic model (TMDL — where the DAX lives). A
+      // missing reference or cross-workspace model is noted in the summary, not fatal.
+      let modelFiles: string[] = []
+      let modelError: string | undefined
+      if (!def.modelId) {
+        modelError = 'no semantic model reference found in the report'
+      } else {
+        onProgress('code', 'Fetching semantic model code (DAX)…')
+        const model = await window.api.fabric.semanticModelDefinition(
+          workspaceId,
+          def.modelId,
+          project.path
+        )
+        if (model.ok) {
+          modelFiles = model.files ?? []
+        } else {
+          modelError = model.error ?? 'the semantic model could not be downloaded'
+        }
+      }
+
+      const reportSummary = `${reportFiles.length} report file${reportFiles.length === 1 ? '' : 's'}`
+      const modelSummary = modelFiles.length
+        ? `, ${modelFiles.length} model file${modelFiles.length === 1 ? '' : 's'}`
+        : modelError
+          ? ', semantic model skipped'
+          : ''
+      onProgress('code', `${reportSummary}${modelSummary}`, 'done')
+
+      // Capture each report page as an image so the agent has a pixel-accurate
+      // visual reference alongside the PBIR. Best-effort: image export is
+      // tenant-blocked on many tenants (so we export a PDF and rasterize it with
+      // pdf.js), and PDF export needs a capacity-backed workspace — any failure is
+      // reported as "skipped", never fatal to the migration.
+      let pageShots: PendingShot[] = []
+      onProgress('pages', 'Exporting the report to PDF…')
+      try {
+        const pdf = await window.api.fabric.exportReportPdf(workspaceId, report.id, project.path)
+        if (pdf.ok && pdf.pdfBase64) {
+          onProgress('pages', 'Rendering report pages to images…')
+          pageShots = await renderPdfToShots(pdf.pdfBase64)
+          if (pageShots.length) {
+            onProgress(
+              'pages',
+              `${pageShots.length} page image${pageShots.length === 1 ? '' : 's'} captured`,
+              'done'
+            )
+          } else {
+            onProgress('pages', 'No visible report pages to capture.', 'skipped')
+          }
+        } else {
+          onProgress(
+            'pages',
+            pdf.error ?? 'Report-page export is unavailable for this report — skipped.',
+            'skipped'
+          )
+        }
+      } catch (e) {
+        onProgress('pages', `Skipped (${e instanceof Error ? e.message : String(e)}).`, 'skipped')
+      }
+
+      const reportList = reportFiles.map((f) => `- source-report/${f}`).join('\n')
+      const modelList = modelFiles.map((f) => `- source-model/${f}`).join('\n')
+
+      // The app should CONNECT to the report's existing Fabric semantic model and
+      // query it live — never copy or reload the data, and never recreate the model
+      // as Rayfin `data` entities. The TMDL in source-model/ is the schema + DAX
+      // *reference* (metadata, not data). Hand the agent the model's coordinates
+      // (workspace + dataset id) so it can wire a live DAX query path.
+      const modelSection = modelList
+        ? '\n\nThis report is powered by an **existing Fabric semantic model** ' +
+          `(workspace \`${workspaceId}\`, dataset \`${def.modelId}\`). Its definition — ` +
+          'tables, relationships, and the DAX measures — is in the `source-model/` folder as ' +
+          `TMDL (schema/metadata, not data):\n\n${modelList}\n\n` +
+          "**Use that semantic model as the app's data source: connect to it and query it live " +
+          "(via the Fabric DAX `executeQueries` REST endpoint, authenticated with the app's " +
+          'Fabric brokered auth). Do NOT import, copy, or duplicate the data, and do NOT ' +
+          'recreate the model as Rayfin `data` entities — the data stays in the semantic model ' +
+          'and the app reads it on demand.** Reuse the exact DAX measure names from the TMDL so ' +
+          'the numbers match the original report. You can disable the `data` service in ' +
+          "`rayfin/rayfin.yml` since you won't be provisioning a separate database."
+        : def.modelId
+          ? '\n\nThis report is powered by an existing Fabric semantic model ' +
+            `(workspace \`${workspaceId}\`, dataset \`${def.modelId}\`), but I couldn't download ` +
+            `its TMDL definition (${modelError ?? 'unknown reason'}). Still, wire the app to query ` +
+            'that model live via the Fabric DAX `executeQueries` endpoint rather than copying data.'
+          : "\n\nNote: I couldn't resolve the semantic model this report is bound to " +
+            `(${modelError ?? 'no model reference found'}). Tell me the workspace + dataset id and ` +
+            "I'll wire the app to query it — we should read from the existing model, not copy data."
+
+      // When we captured page images, tell the agent they're attached so it uses
+      // them as the visual ground truth for layout, colours, and chart types.
+      const pagesSection = pageShots.length
+        ? '\n\nI\'ve also attached rendered images of each report page (exported straight from ' +
+          'the live report). Use them as the visual reference for the layout, colours, chart ' +
+          'types, and overall look — match them as closely as the Rayfin component set allows.'
+        : ''
+
+      const prompt =
+        `I've imported a Power BI report ("${report.displayName}") from Fabric workspace ` +
+        `\`${workspaceId}\`. Its definition files are in the \`source-report/\` folder:\n\n` +
+        `${reportList}\n\n` +
+        "These describe the report's pages, visuals, and layout — use them as the spec for the " +
+        "app's UI." +
+        modelSection +
+        pagesSection +
+        '\n\nPlease read everything, then help me rebuild this as a Rayfin Data App that reads ' +
+        'from the existing semantic model. Start by summarizing the report (pages, visuals, key ' +
+        "measures) and proposing a plan. Do not run `npm install` — Fabricator installs the " +
+        "project's dependencies for you."
+      migratePromptRef.current = {
+        id: `migrate-pbi-${Date.now()}`,
+        projectId: project.id,
+        display: `Migrate “${report.displayName}”`,
+        prompt,
+        // Auto-submit once the first deploy clears the chat gate: the user lands
+        // in chat and the migrate prompt sends itself (staged in the composer
+        // meanwhile so they can see what's going out).
+        autoSend: true,
+        attachments: pageShots
+      }
+
+      return null
+    },
+    [migrateSel]
+  )
+
+  // Undo a migrate project (delete its files) when the user cancels the flow, so
+  // no empty scaffold is left cluttering the workspace / colliding on retry.
+  const rollbackMigrateProject = useCallback(
+    async (project: StudioProject): Promise<void> => {
+      try {
+        await window.api.projects.remove(project.id, true)
+      } catch {
+        // best-effort cleanup; ignore
+      }
+      await refreshProjects()
+    },
+    [refreshProjects]
+  )
+
+  // Drop the stashed migrate prompt into the chat (once the create → fetch →
+  // deploy flow finishes) and clear the migrate selection. A no-op for the normal
+  // create flow (nothing stashed).
+  const seedMigrateChat = useCallback((): void => {
+    const pending = migratePromptRef.current
+    migratePromptRef.current = null
+    setMigrateSel(null)
+    if (pending) setChatOutbound(pending)
+  }, [])
+
   useEffect(() => {
     const id = projects?.activeProjectId
     if (!id) {
@@ -854,8 +1058,23 @@ export default function Workbench({
         <CreateProjectScreen
           mode={createMode}
           projectName={active?.name}
+          migrate={
+            migrateSel
+              ? {
+                  projectName: migrateSel.report.displayName,
+                  onFetchReportCode: fetchMigrateReportCode,
+                  onRollback: rollbackMigrateProject
+                }
+              : undefined
+          }
           deploying={Boolean(active && deploys[active.id]?.running)}
-          onCancel={() => setCreateMode(null)}
+          onCancel={() => {
+            if (migrateSel) {
+              migratePromptRef.current = null
+              setMigrateSel(null)
+            }
+            setCreateMode(null)
+          }}
           onCreated={() => void refreshProjects()}
           onSignedIn={() => void onAuthChanged()}
           onDeploy={(depName, workspaceId) => {
@@ -866,6 +1085,7 @@ export default function Workbench({
             const projectId = active.id
             setCreateMode(null)
             setViewMode('build')
+            seedMigrateChat()
             void (async () => {
               try {
                 await window.api.deploy.setName(projectId, workspaceId, depName)
@@ -875,7 +1095,11 @@ export default function Workbench({
               await requestUserDeploy(projectId, workspaceId)
             })()
           }}
-          onContinueWithoutDeploy={() => setCreateMode(null)}
+          onContinueWithoutDeploy={() => {
+            setViewMode('build')
+            seedMigrateChat()
+            setCreateMode(null)
+          }}
         />
       ) : (
         <div className="workbench">
@@ -1123,6 +1347,7 @@ export default function Workbench({
                   onNewProject={() => setCreateMode('create')}
                   onOpenExisting={openExisting}
                   onCloneFromGitHub={() => setShowClone(true)}
+                  onMigratePowerBIReport={() => setShowMigratePbi(true)}
                   onChangeWorkspaceRoot={changeWorkspaceRoot}
                 />
               </>
@@ -1206,6 +1431,18 @@ export default function Workbench({
           project={confirmDelete}
           onRemoved={(next) => setProjects(next)}
           onClose={() => setConfirmDelete(null)}
+        />
+      )}
+
+      {showMigratePbi && (
+        <MigratePowerBIReportModal
+          onClose={() => setShowMigratePbi(false)}
+          onSelect={(workspaceId, report) => {
+            setShowMigratePbi(false)
+            migratePromptRef.current = null
+            setMigrateSel({ workspaceId, report })
+            setCreateMode('create')
+          }}
         />
       )}
 

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -174,6 +174,64 @@ export interface FabricWorkspacesResult {
   error?: string
 }
 
+/** A Power BI report in a Fabric workspace the user can migrate. */
+export interface FabricReport {
+  id: string
+  displayName: string
+  /** Report description, when set. */
+  description?: string
+  /** Direct link to the report in the Fabric/Power BI portal, when known. */
+  webUrl?: string
+}
+
+/** Outcome of listing a workspace's Power BI reports (never throws across IPC). */
+export interface FabricReportsResult {
+  ok: boolean
+  reports?: FabricReport[]
+  /** True when the failure was a missing/expired Fabric session. */
+  needsLogin?: boolean
+  error?: string
+}
+
+/** Outcome of downloading a report's PBIR definition to disk (never throws). */
+export interface FabricReportDefinitionResult {
+  ok: boolean
+  /** Relative paths (under the destination dir) of the files written. */
+  files?: string[]
+  /** Absolute directory the report files were written into. */
+  dir?: string
+  /** The report's bound semantic model id (report downloads only), resolved from
+   * its `definition.pbir` so the caller can download the model next. */
+  modelId?: string
+  /** True when the failure was a missing/expired Fabric session. */
+  needsLogin?: boolean
+  error?: string
+}
+
+/** Outcome of the interactive Fabric sign-in (never throws across IPC). */
+export interface FabricSignInResult {
+  ok: boolean
+  error?: string
+}
+
+/** Outcome of exporting a Power BI report to PDF (never throws across IPC). The
+ * PDF is returned inline (base64) so the renderer can rasterize each page to an
+ * image with pdf.js and stage them as chat attachments. Best-effort: a failure
+ * (image/PDF export disabled on the tenant, or a non-capacity workspace) is
+ * reported, not thrown, and never blocks the migration. */
+export interface FabricExportPdfResult {
+  ok: boolean
+  /** Absolute path the exported PDF was written to (`source-report/report.pdf`). */
+  pdfPath?: string
+  /** The exported PDF, base64-encoded, for renderer rasterization. */
+  pdfBase64?: string
+  /** Byte length of the exported PDF. */
+  bytes?: number
+  /** True when the failure was a missing/expired Fabric session. */
+  needsLogin?: boolean
+  error?: string
+}
+
 /** A dedicated capacity the user can create a workspace on. */
 export interface FabricCapacity {
   id: string
@@ -1552,6 +1610,47 @@ export interface RayfinStudioApi {
   fabric: {
     /** List the signed-in user's Fabric workspaces (with capacity / F-SKU info). */
     listWorkspaces: () => Promise<FabricWorkspacesResult>
+    /** List the Power BI reports in a workspace (for the migrate-report picker). */
+    listReports: (workspaceId: string) => Promise<FabricReportsResult>
+    /**
+     * Download a report's public definition (PBIR) into `<projectDir>/source-report`
+     * so the agent can rebuild it. Follows the getDefinition long-running operation
+     * and writes each decoded part to disk; never throws.
+     */
+    reportDefinition: (
+      workspaceId: string,
+      reportId: string,
+      projectDir: string
+    ) => Promise<FabricReportDefinitionResult>
+    /**
+     * Download a semantic model's definition (TMDL — the DAX measures/tables)
+     * into `<projectDir>/source-model`. `modelId` comes from a prior
+     * `reportDefinition` call. Best-effort: a failure is reported, not thrown.
+     */
+    semanticModelDefinition: (
+      workspaceId: string,
+      modelId: string,
+      projectDir: string
+    ) => Promise<FabricReportDefinitionResult>
+    /**
+     * Export a Power BI report to a PDF (every page) via the Power BI `ExportTo`
+     * REST API, writing it to `<projectDir>/source-report/report.pdf` and
+     * returning it base64-encoded so the renderer can rasterize each page into an
+     * image for the migrate chat hand-off. Best-effort: image export is
+     * tenant-blocked on many tenants (so we export PDF), and PDF export needs a
+     * capacity-backed workspace — a failure is reported, not thrown.
+     */
+    exportReportPdf: (
+      workspaceId: string,
+      reportId: string,
+      projectDir: string
+    ) => Promise<FabricExportPdfResult>
+    /**
+     * Open the interactive Microsoft Fabric sign-in window (returns immediately
+     * when already signed in). Used by the migrate-report flow so workspaces can
+     * be listed from the Home screen where no project is active.
+     */
+    signIn: () => Promise<FabricSignInResult>
     /** List eligible (F-SKU / P-SKU) capacities the user can create a workspace on. */
     listCapacities: () => Promise<FabricCapacitiesResult>
     /** Create + assign a new workspace to `capacityId`; region follows the capacity. */

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -227,7 +227,7 @@ export interface FabricExportPdfResult {
   pdfBase64?: string
   /** Byte length of the exported PDF. */
   bytes?: number
-  /** True when the failure was a missing/expired Fabric session. */
+  /** True when the failure was that the Azure CLI (`az`) isn't signed in. */
   needsLogin?: boolean
   error?: string
 }

--- a/src/shared/ipc.ts
+++ b/src/shared/ipc.ts
@@ -1646,6 +1646,14 @@ export interface RayfinStudioApi {
       projectDir: string
     ) => Promise<FabricExportPdfResult>
     /**
+     * Persist the renderer's rasterized report pages (PNG data URLs) into
+     * `<projectDir>/source-report/pages/` as `page-01.png`, … and return their
+     * absolute paths. These live in the project (not a temp dir), so the build
+     * agent can re-open them on any turn as a persistent visual reference;
+     * `source-report/` is git-ignored so they're never committed or bundled.
+     */
+    saveReportPages: (projectDir: string, pages: string[]) => Promise<string[]>
+    /**
      * Open the interactive Microsoft Fabric sign-in window (returns immediately
      * when already signed in). Used by the migrate-report flow so workspaces can
      * be listed from the Home screen where no project is active.


### PR DESCRIPTION
## Summary

Adds a guided **Details → Migrate → Deploy** flow that scaffolds a Rayfin data app from an existing Power BI report and hands the agent everything it needs to rebuild it against the live semantic model.

- **Migrate picker + create screen.** Pick a Fabric report, scaffold a data-app project, then run a two-substep fetch (report/model code, then report-page capture) before Deploy.
- **Fabric export.** New `fabric_export_report_pdf` command exports the report to PDF via the Power BI ExportTo API (image export is tenant-blocked on many tenants); the renderer rasterizes each visible page with pdf.js and stages them as chat attachments.
- **Correct token scope.** ExportTo is called with a token minted from the signed-in Azure CLI (`az account get-access-token --resource https://analysis.windows.net/powerbi/api`) instead of the Rayfin CLI's Fabric-only MSAL token, which ExportTo rejects with 401. Export failures now surface as a visible, non-blocking sub-step with an `az login` CTA instead of silently skipping.
- **Durable page images.** `fabric_save_report_pages` persists rasterized pages to `<project>/source-report/pages/page-NN.png` (gitignored, survives chat-turn cleanup) so the build agent can re-open them on any turn as a visual reference.
- **`match-source-report` skill.** A self-contained skill that activates only when `source-report/` exists: it makes the source report the design direction (extract palette/typography/layout, set `global.css` tokens up front), superseding the default "defer theming" guidance for migrations only. Inert for greenfield apps and removable to opt out.
- **Seed prompt.** Auto-submits a rebuild prompt wired to the existing semantic model (query live via DAX `executeQueries`, never copy data), with the rendered page images attached as the visual reference.

Reference folders (`source-report/`, `source-model/`) are idempotently added to the project `.gitignore`.

## Linked issue

N/A — no tracking issue.

## Type of change

- [ ] Bug fix
- [x] Feature
- [ ] Documentation
- [ ] Refactoring or maintenance
- [ ] Other

## Checklist

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run build:renderer` passes
- [x] `cargo check` was run from `src-tauri` (Rust changed)
- [x] Documentation was updated, if needed (adds the `match-source-report` skill)

## Screenshots or notes

- New UI surface: `MigratePowerBIReportModal` picker plus migrate substeps on the create screen; new `.migrate-fetch*` / `.ws-signin` styles in `main.css`.
- The PDF export step requires the user to be signed in via `az login` (Power BI ExportTo scope). It degrades gracefully with a red, non-blocking CTA if the token is missing.
- Rebased onto `master` (v0.94.0). The only merge conflict was additive CSS in `main.css`, resolved by keeping both rule sets.
- 257 renderer tests pass (`npm run test`).
